### PR TITLE
Version public API with /v1 path prefix and refactor init UX

### DIFF
--- a/.github/workflows/generate-registry.yml
+++ b/.github/workflows/generate-registry.yml
@@ -7,6 +7,8 @@ on:
       - main
     paths:
       - "public/v1/templates/**"
+      - ".github/workflows/generate-registry.yml"
+      - "scripts/ci/detect_template_changes.sh"
 
 permissions:
   contents: write

--- a/public/v1/templates/amp/provider.toml
+++ b/public/v1/templates/amp/provider.toml
@@ -1,15 +1,15 @@
 [providers.amp.commands]
-template = "https://dotagents.soorya-u.dev/templates/amp/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/amp/command.hbs"
 target = "{{dir.workspace}}/.agents/commands/{{command.name}}.md"
 
 [providers.amp.skills]
-template = "https://dotagents.soorya-u.dev/templates/amp/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/amp/skill.hbs"
 target = "{{dir.workspace}}/.agents/skills/{{skill.name}}/SKILL.md"
 
 [providers.amp.instructions]
-template = "https://dotagents.soorya-u.dev/templates/amp/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/amp/instruction.hbs"
 target = "{{ dir.workspace }}/AGENTS.md"
 
 [providers.amp.mcp]
-template = "https://dotagents.soorya-u.dev/templates/amp/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/amp/mcp.hbs"
 target = "{{ dir.workspace }}/.amp/settings.jsonc"

--- a/public/v1/templates/auggie/provider.toml
+++ b/public/v1/templates/auggie/provider.toml
@@ -1,16 +1,16 @@
 # Augment Commands
 [providers.auggie.commands]
-template = "https://dotagents.soorya-u.dev/templates/auggie/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/auggie/command.hbs"
 target = "{{dir.workspace}}/.augment/commands/{{command.name}}.md"
 
 [providers.auggie.skills]
-template = "https://dotagents.soorya-u.dev/templates/auggie/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/auggie/skill.hbs"
 target = "{{dir.workspace}}/.augment/skills/{{skill.name}}/SKILL.md"
 
 [providers.auggie.instructions]
-template = "https://dotagents.soorya-u.dev/templates/auggie/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/auggie/instruction.hbs"
 target = "{{ dir.workspace }}/AGENTS.md"
 
 [providers.auggie.mcp]
-template = "https://dotagents.soorya-u.dev/templates/auggie/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/auggie/mcp.hbs"
 target = "{{ dir.workspace }}/.augment/settings.json"

--- a/public/v1/templates/autohand/provider.toml
+++ b/public/v1/templates/autohand/provider.toml
@@ -1,11 +1,11 @@
 [providers.autohand.skills]
-template = "https://dotagents.soorya-u.dev/templates/autohand/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/autohand/skill.hbs"
 target = "{{dir.workspace}}/.autohand/skills/{{skill.name}}/SKILL.md"
 
 [providers.autohand.instructions]
-template = "https://dotagents.soorya-u.dev/templates/autohand/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/autohand/instruction.hbs"
 target = "{{ dir.workspace }}/AGENTS.md"
 
 [providers.autohand.mcp]
-template = "https://dotagents.soorya-u.dev/templates/autohand/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/autohand/mcp.hbs"
 target = "{{ dir.workspace }}/.autohand/config.json"

--- a/public/v1/templates/claude/provider.toml
+++ b/public/v1/templates/claude/provider.toml
@@ -1,17 +1,17 @@
 # Claude Commands
 [providers.claude.commands]
-template = "https://dotagents.soorya-u.dev/templates/claude/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/claude/command.hbs"
 target = "{{dir.workspace}}/.claude/commands/{{command.name}}.md"
 
 # Claude Skills
 [providers.claude.skills]
-template = "https://dotagents.soorya-u.dev/templates/claude/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/claude/skill.hbs"
 target = "{{dir.workspace}}/.claude/skills/{{skill.name}}/SKILL.md"
 
 [providers.claude.instructions]
-template = "https://dotagents.soorya-u.dev/templates/claude/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/claude/instruction.hbs"
 target = "{{ dir.workspace }}/CLAUDE.md"
 
 [providers.claude.mcp]
-template = "https://dotagents.soorya-u.dev/templates/claude/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/claude/mcp.hbs"
 target = "{{ dir.workspace }}/.mcp.json"

--- a/public/v1/templates/cline/provider.toml
+++ b/public/v1/templates/cline/provider.toml
@@ -1,11 +1,11 @@
 [providers.cline.commands]
-template = "https://dotagents.soorya-u.dev/templates/cline/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/cline/command.hbs"
 target = "{{dir.workspace}}/.clinerules/workflows/{{command.name}}.md"
 
 [providers.cline.skills]
-template = "https://dotagents.soorya-u.dev/templates/cline/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/cline/skill.hbs"
 target = "{{dir.workspace}}/.cline/skills/{{skill.name}}/SKILL.md"
 
 [providers.cline.instructions]
-template = "https://dotagents.soorya-u.dev/templates/cline/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/cline/instruction.hbs"
 target = "{{ dir.workspace }}/.clinerules/instructions.md"

--- a/public/v1/templates/codebuddy/provider.toml
+++ b/public/v1/templates/codebuddy/provider.toml
@@ -1,19 +1,19 @@
 # CodeBuddy Instructions
 [providers.codebuddy.instructions]
-template = "https://dotagents.soorya-u.dev/templates/codebuddy/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/codebuddy/instruction.hbs"
 target = "{{dir.workspace}}/CODEBUDDY.md"
 
 # CodeBuddy Skills
 [providers.codebuddy.skills]
-template = "https://dotagents.soorya-u.dev/templates/codebuddy/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/codebuddy/skill.hbs"
 target = "{{dir.workspace}}/.codebuddy/skills/{{skill.name}}/SKILL.md"
 
 # CodeBuddy Commands
 [providers.codebuddy.commands]
-template = "https://dotagents.soorya-u.dev/templates/codebuddy/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/codebuddy/command.hbs"
 target = "{{dir.workspace}}/.codebuddy/commands/{{command.name}}.md"
 
 # CodeBuddy MCP
 [providers.codebuddy.mcp]
-template = "https://dotagents.soorya-u.dev/templates/codebuddy/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/codebuddy/mcp.hbs"
 target = "{{dir.workspace}}/.codebuddy/mcp.json"

--- a/public/v1/templates/codex/provider.toml
+++ b/public/v1/templates/codex/provider.toml
@@ -1,17 +1,17 @@
 # Codex Commands
 [providers.codex.commands]
-template = "https://dotagents.soorya-u.dev/templates/codex/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/codex/command.hbs"
 target = "{{dir.workspace}}/.codex/prompts/{{command.name}}.md"
 
 # Codex Skills
 [providers.codex.skills]
-template = "https://dotagents.soorya-u.dev/templates/codex/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/codex/skill.hbs"
 target = "{{dir.workspace}}/.agents/skills/{{skill.name}}/SKILL.md"
 
 [providers.codex.instructions]
-template = "https://dotagents.soorya-u.dev/templates/codex/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/codex/instruction.hbs"
 target = "{{ dir.workspace }}/AGENTS.md"
 
 [providers.codex.mcp]
-template = "https://dotagents.soorya-u.dev/templates/codex/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/codex/mcp.hbs"
 target = "{{ dir.workspace }}/.codex/config.toml"

--- a/public/v1/templates/copilot/provider.toml
+++ b/public/v1/templates/copilot/provider.toml
@@ -1,19 +1,19 @@
 # Copilot Instructions
 [providers.copilot.instructions]
-template = "https://dotagents.soorya-u.dev/templates/copilot/instructions.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/copilot/instructions.hbs"
 target = "{{dir.workspace}}/.github/copilot-instructions.md"
 
 # Copilot Commands
 [providers.copilot.commands]
-template = "https://dotagents.soorya-u.dev/templates/copilot/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/copilot/command.hbs"
 target = "{{dir.workspace}}/.github/prompts/{{command.name}}.prompt.md"
 
 # Copilot Skills
 [providers.copilot.skills]
-template = "https://dotagents.soorya-u.dev/templates/copilot/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/copilot/skill.hbs"
 target = "{{dir.workspace}}/.github/skills/{{skill.name}}/SKILL.md"
 
 # Copilot MCP
 [providers.copilot.mcp]
-template = "https://dotagents.soorya-u.dev/templates/copilot/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/copilot/mcp.hbs"
 target = "{{dir.home}}/.copilot/mcp-config.json"

--- a/public/v1/templates/cursor/provider.toml
+++ b/public/v1/templates/cursor/provider.toml
@@ -1,17 +1,17 @@
 # Cursor Commands
 [providers.cursor.commands]
-template = "https://dotagents.soorya-u.dev/templates/cursor/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/cursor/command.hbs"
 target = "{{dir.workspace}}/.cursor/commands/{{command.name}}.md"
 
 # Cursor Skills
 [providers.cursor.skills]
-template = "https://dotagents.soorya-u.dev/templates/cursor/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/cursor/skill.hbs"
 target = "{{dir.workspace}}/.agents/skills/{{skill.name}}/SKILL.md"
 
 [providers.cursor.instructions]
-template = "https://dotagents.soorya-u.dev/templates/cursor/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/cursor/instruction.hbs"
 target = "{{dir.workspace}}/AGENTS.md"
 
 [providers.cursor.mcp]
-template = "https://dotagents.soorya-u.dev/templates/cursor/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/cursor/mcp.hbs"
 target = "{{dir.workspace}}/.cursor/mcp.json"

--- a/public/v1/templates/deepagents/provider.toml
+++ b/public/v1/templates/deepagents/provider.toml
@@ -1,14 +1,14 @@
 # Deep Agents Skills
 [providers.deepagents.skills]
-template = "https://dotagents.soorya-u.dev/templates/deepagents/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/deepagents/skill.hbs"
 target = "{{dir.workspace}}/skills/{{skill.name}}/SKILL.md"
 
 # Deep Agents Instructions
 [providers.deepagents.instructions]
-template = "https://dotagents.soorya-u.dev/templates/deepagents/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/deepagents/instruction.hbs"
 target = "{{ dir.workspace }}/AGENTS.md"
 
 # Deep Agents MCP
 [providers.deepagents.mcp]
-template = "https://dotagents.soorya-u.dev/templates/deepagents/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/deepagents/mcp.hbs"
 target = "{{ dir.workspace }}/.mcp.json"

--- a/public/v1/templates/factory-droid/provider.toml
+++ b/public/v1/templates/factory-droid/provider.toml
@@ -1,19 +1,19 @@
 # Factory Droid Commands
 [providers.factory-droid.commands]
-template = "https://dotagents.soorya-u.dev/templates/factory-droid/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/factory-droid/command.hbs"
 target = "{{dir.workspace}}/.factory/commands/{{command.name}}.md"
 
 # Factory Droid Skills
 [providers.factory-droid.skills]
-template = "https://dotagents.soorya-u.dev/templates/factory-droid/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/factory-droid/skill.hbs"
 target = "{{dir.workspace}}/.factory/skills/{{skill.name}}/SKILL.md"
 
 # Factory Droid Instructions
 [providers.factory-droid.instructions]
-template = "https://dotagents.soorya-u.dev/templates/factory-droid/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/factory-droid/instruction.hbs"
 target = "{{ dir.workspace }}/AGENTS.md"
 
 # Factory Droid MCP
 [providers.factory-droid.mcp]
-template = "https://dotagents.soorya-u.dev/templates/factory-droid/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/factory-droid/mcp.hbs"
 target = "{{ dir.workspace }}/.factory/mcp.json"

--- a/public/v1/templates/gemini/provider.toml
+++ b/public/v1/templates/gemini/provider.toml
@@ -1,19 +1,19 @@
 # Gemini Commands
 [providers.gemini.commands]
-template = "https://dotagents.soorya-u.dev/templates/gemini/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/gemini/command.hbs"
 target = "{{dir.workspace}}/.gemini/commands/{{command.name}}.toml"
 
 # Gemini Skills
 [providers.gemini.skills]
-template = "https://dotagents.soorya-u.dev/templates/gemini/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/gemini/skill.hbs"
 target = "{{dir.workspace}}/.gemini/skills/{{skill.name}}/SKILL.md"
 
 # Gemini Instructions
 [providers.gemini.instructions]
-template = "https://dotagents.soorya-u.dev/templates/gemini/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/gemini/instruction.hbs"
 target = "{{ dir.workspace }}/GEMINI.md"
 
 # Gemini MCP
 [providers.gemini.mcp]
-template = "https://dotagents.soorya-u.dev/templates/gemini/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/gemini/mcp.hbs"
 target = "{{ dir.workspace }}/.gemini/settings.json"

--- a/public/v1/templates/goose/provider.toml
+++ b/public/v1/templates/goose/provider.toml
@@ -1,19 +1,19 @@
 # Goose Instructions
 [providers.goose.instructions]
-template = "https://dotagents.soorya-u.dev/templates/goose/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/goose/instruction.hbs"
 target = "{{dir.workspace}}/AGENTS.md"
 
 # Goose Skills
 [providers.goose.skills]
-template = "https://dotagents.soorya-u.dev/templates/goose/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/goose/skill.hbs"
 target = "{{dir.workspace}}/.agents/skills/{{skill.name}}/SKILL.md"
 
 # Goose Commands (as Recipes)
 [providers.goose.commands]
-template = "https://dotagents.soorya-u.dev/templates/goose/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/goose/command.hbs"
 target = "{{dir.workspace}}/.goose/recipes/{{command.name}}.yaml"
 
 # Goose MCP (Extensions — requires manual merge into ~/.config/goose/config.yaml)
 [providers.goose.mcp]
-template = "https://dotagents.soorya-u.dev/templates/goose/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/goose/mcp.hbs"
 target = "{{dir.workspace}}/.goose/extensions.yaml"

--- a/public/v1/templates/junie/provider.toml
+++ b/public/v1/templates/junie/provider.toml
@@ -1,19 +1,19 @@
 # Junie Instructions (requires "guidelines-location": "./guidelines.md" in .junie/config.json)
 [providers.junie.instructions]
-template = "https://dotagents.soorya-u.dev/templates/junie/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/junie/instruction.hbs"
 target = "{{dir.workspace}}/.junie/guidelines.md"
 
 # Junie Skills
 [providers.junie.skills]
-template = "https://dotagents.soorya-u.dev/templates/junie/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/junie/skill.hbs"
 target = "{{dir.workspace}}/.junie/skills/{{skill.name}}/SKILL.md"
 
 # Junie Commands (Custom Slash Commands)
 [providers.junie.commands]
-template = "https://dotagents.soorya-u.dev/templates/junie/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/junie/command.hbs"
 target = "{{dir.workspace}}/.junie/commands/{{command.name}}.md"
 
 # Junie MCP
 [providers.junie.mcp]
-template = "https://dotagents.soorya-u.dev/templates/junie/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/junie/mcp.hbs"
 target = "{{dir.workspace}}/.junie/mcp/mcp.json"

--- a/public/v1/templates/kilocode/provider.toml
+++ b/public/v1/templates/kilocode/provider.toml
@@ -1,19 +1,19 @@
 # KiloCode Instructions
 [providers.kilocode.instructions]
-template = "https://dotagents.soorya-u.dev/templates/kilocode/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/kilocode/instruction.hbs"
 target = "{{dir.workspace}}/AGENTS.md"
 
 # KiloCode Skills
 [providers.kilocode.skills]
-template = "https://dotagents.soorya-u.dev/templates/kilocode/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/kilocode/skill.hbs"
 target = "{{dir.workspace}}/.kilo/skills/{{skill.name}}/SKILL.md"
 
 # KiloCode Commands (Workflows / Slash Commands)
 [providers.kilocode.commands]
-template = "https://dotagents.soorya-u.dev/templates/kilocode/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/kilocode/command.hbs"
 target = "{{dir.workspace}}/.kilo/commands/{{command.name}}.md"
 
 # KiloCode MCP (requires manual merge into .kilo/kilo.jsonc under the "mcp" key)
 [providers.kilocode.mcp]
-template = "https://dotagents.soorya-u.dev/templates/kilocode/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/kilocode/mcp.hbs"
 target = "{{dir.workspace}}/.kilo/mcp.json"

--- a/public/v1/templates/kimi/provider.toml
+++ b/public/v1/templates/kimi/provider.toml
@@ -1,14 +1,14 @@
 # Kimi Instructions
 [providers.kimi.instructions]
-template = "https://dotagents.soorya-u.dev/templates/kimi/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/kimi/instruction.hbs"
 target = "{{dir.workspace}}/AGENTS.md"
 
 # Kimi Skills
 [providers.kimi.skills]
-template = "https://dotagents.soorya-u.dev/templates/kimi/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/kimi/skill.hbs"
 target = "{{dir.workspace}}/.kimi/skills/{{skill.name}}/SKILL.md"
 
 # Kimi MCP
 [providers.kimi.mcp]
-template = "https://dotagents.soorya-u.dev/templates/kimi/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/kimi/mcp.hbs"
 target = "{{dir.home}}/.kimi/mcp.json"

--- a/public/v1/templates/mistral-vibe/provider.toml
+++ b/public/v1/templates/mistral-vibe/provider.toml
@@ -1,14 +1,14 @@
 # Mistral Vibe Instructions
 [providers.mistral-vibe.instructions]
-template = "https://dotagents.soorya-u.dev/templates/mistral-vibe/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/mistral-vibe/instruction.hbs"
 target = "{{dir.workspace}}/AGENTS.md"
 
 # Mistral Vibe Skills
 [providers.mistral-vibe.skills]
-template = "https://dotagents.soorya-u.dev/templates/mistral-vibe/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/mistral-vibe/skill.hbs"
 target = "{{dir.workspace}}/.vibe/skills/{{skill.name}}/SKILL.md"
 
 # Mistral Vibe MCP (requires manual merge into .vibe/config.toml under [[mcp_servers]])
 [providers.mistral-vibe.mcp]
-template = "https://dotagents.soorya-u.dev/templates/mistral-vibe/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/mistral-vibe/mcp.hbs"
 target = "{{dir.workspace}}/.vibe/mcp.toml"

--- a/public/v1/templates/opencode/provider.toml
+++ b/public/v1/templates/opencode/provider.toml
@@ -1,19 +1,19 @@
 # OpenCode Instructions
 [providers.opencode.instructions]
-template = "https://dotagents.soorya-u.dev/templates/opencode/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/opencode/instruction.hbs"
 target = "{{dir.workspace}}/AGENTS.md"
 
 # OpenCode Skills
 [providers.opencode.skills]
-template = "https://dotagents.soorya-u.dev/templates/opencode/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/opencode/skill.hbs"
 target = "{{dir.workspace}}/.opencode/skills/{{skill.name}}/SKILL.md"
 
 # OpenCode Commands
 [providers.opencode.commands]
-template = "https://dotagents.soorya-u.dev/templates/opencode/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/opencode/command.hbs"
 target = "{{dir.workspace}}/.opencode/commands/{{command.name}}.md"
 
 # OpenCode MCP (overwrites opencode.json; merge manually if other project settings exist)
 [providers.opencode.mcp]
-template = "https://dotagents.soorya-u.dev/templates/opencode/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/opencode/mcp.hbs"
 target = "{{dir.workspace}}/opencode.json"

--- a/public/v1/templates/pi/provider.toml
+++ b/public/v1/templates/pi/provider.toml
@@ -1,9 +1,9 @@
 # Pi Commands (Prompt Templates)
 [providers.pi.commands]
-template = "https://dotagents.soorya-u.dev/templates/pi/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/pi/command.hbs"
 target = "{{dir.workspace}}/.pi/prompts/{{command.name}}.md"
 
 # Pi Skills
 [providers.pi.skills]
-template = "https://dotagents.soorya-u.dev/templates/pi/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/pi/skill.hbs"
 target = "{{dir.workspace}}/.pi/skills/{{skill.name}}/SKILL.md"

--- a/public/v1/templates/qoder-cli/provider.toml
+++ b/public/v1/templates/qoder-cli/provider.toml
@@ -1,19 +1,19 @@
 # Qoder CLI Instructions
 [providers.qoder-cli.instructions]
-template = "https://dotagents.soorya-u.dev/templates/qoder-cli/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/qoder-cli/instruction.hbs"
 target = "{{dir.workspace}}/AGENTS.md"
 
 # Qoder CLI Skills
 [providers.qoder-cli.skills]
-template = "https://dotagents.soorya-u.dev/templates/qoder-cli/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/qoder-cli/skill.hbs"
 target = "{{dir.workspace}}/.qoder/skills/{{skill.name}}/SKILL.md"
 
 # Qoder CLI Commands
 [providers.qoder-cli.commands]
-template = "https://dotagents.soorya-u.dev/templates/qoder-cli/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/qoder-cli/command.hbs"
 target = "{{dir.workspace}}/.qoder/commands/{{command.name}}.md"
 
 # Qoder CLI MCP
 [providers.qoder-cli.mcp]
-template = "https://dotagents.soorya-u.dev/templates/qoder-cli/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/qoder-cli/mcp.hbs"
 target = "{{dir.workspace}}/.mcp.json"

--- a/public/v1/templates/qwen/provider.toml
+++ b/public/v1/templates/qwen/provider.toml
@@ -1,14 +1,14 @@
 # Qwen Code Commands
 [providers.qwen.commands]
-template = "https://dotagents.soorya-u.dev/templates/qwen/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/qwen/command.hbs"
 target = "{{dir.workspace}}/.qwen/commands/{{command.name}}.md"
 
 # Qwen Code Skills
 [providers.qwen.skills]
-template = "https://dotagents.soorya-u.dev/templates/qwen/skill.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/qwen/skill.hbs"
 target = "{{dir.workspace}}/.qwen/skills/{{skill.name}}/SKILL.md"
 
 # Qwen Code MCP (requires manual merge into .qwen/settings.json under "mcpServers")
 [providers.qwen.mcp]
-template = "https://dotagents.soorya-u.dev/templates/qwen/mcp.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/qwen/mcp.hbs"
 target = "{{dir.workspace}}/.qwen/mcp.json"

--- a/public/v1/templates/registry.json
+++ b/public/v1/templates/registry.json
@@ -2,7 +2,7 @@
   "$schema": "https://dotagents.soorya-u.dev/v1/schemas/registry.schema.json",
   "providers": {
     "amp": {
-      "path": "/templates/amp/provider.toml",
+      "path": "/v1/templates/amp/provider.toml",
       "checksums": {
         "provider.toml": "6d199c09595a7fbaffb1f41714af2f5659bb156ad97f3076c1d1c1653f685ff6",
         "command.hbs": "a57a93257b0307d8c97fa5b41739a2922fe908e8556b050567cf52332c1019aa",
@@ -12,7 +12,7 @@
       }
     },
     "auggie": {
-      "path": "/templates/auggie/provider.toml",
+      "path": "/v1/templates/auggie/provider.toml",
       "checksums": {
         "provider.toml": "717aababee3c279365c8ec04fc956b76261cbb849c4308ea8b207d784800408d",
         "command.hbs": "a57a93257b0307d8c97fa5b41739a2922fe908e8556b050567cf52332c1019aa",
@@ -22,7 +22,7 @@
       }
     },
     "autohand": {
-      "path": "/templates/autohand/provider.toml",
+      "path": "/v1/templates/autohand/provider.toml",
       "checksums": {
         "provider.toml": "e8b24902a05354cd72969e55e900775447f635c7330a76bc18ff53ab1f7ecc5c",
         "instruction.hbs": "9bb2522682a74a16bbd7d290c7eaa0804b2b53642bb39a49e22d849c5b81ec49",
@@ -31,7 +31,7 @@
       }
     },
     "claude": {
-      "path": "/templates/claude/provider.toml",
+      "path": "/v1/templates/claude/provider.toml",
       "checksums": {
         "provider.toml": "be9e78d44028534fb10ad905423eeccad5f56f73a33b00f52807642bec2ed53b",
         "command.hbs": "a57a93257b0307d8c97fa5b41739a2922fe908e8556b050567cf52332c1019aa",
@@ -41,7 +41,7 @@
       }
     },
     "cline": {
-      "path": "/templates/cline/provider.toml",
+      "path": "/v1/templates/cline/provider.toml",
       "checksums": {
         "provider.toml": "fac557944108dd9eb131fc7f8367d5fc8025c879d02fb9667b0f218b81627469",
         "command.hbs": "2ff2983122964767e8a8d98702fbaf57d1e392d5e4cbc8d21b9f494f92b90e94",
@@ -50,7 +50,7 @@
       }
     },
     "codebuddy": {
-      "path": "/templates/codebuddy/provider.toml",
+      "path": "/v1/templates/codebuddy/provider.toml",
       "checksums": {
         "provider.toml": "9326ac7de4f839f56f5ca1125d0e15f83d946ae09b354f57c925aa7f92aa5807",
         "command.hbs": "a57a93257b0307d8c97fa5b41739a2922fe908e8556b050567cf52332c1019aa",
@@ -60,7 +60,7 @@
       }
     },
     "codex": {
-      "path": "/templates/codex/provider.toml",
+      "path": "/v1/templates/codex/provider.toml",
       "checksums": {
         "provider.toml": "53635f9c2a0f865d2baf69065bced9bc446648ed60f8a033541d999d05a1382b",
         "command.hbs": "a57a93257b0307d8c97fa5b41739a2922fe908e8556b050567cf52332c1019aa",
@@ -70,7 +70,7 @@
       }
     },
     "copilot": {
-      "path": "/templates/copilot/provider.toml",
+      "path": "/v1/templates/copilot/provider.toml",
       "checksums": {
         "provider.toml": "86fa7114c96bb5d15a785b08860af4b57d82ad5e39a7ac4d57e69db5585ace2a",
         "command.hbs": "a57a93257b0307d8c97fa5b41739a2922fe908e8556b050567cf52332c1019aa",
@@ -80,7 +80,7 @@
       }
     },
     "cursor": {
-      "path": "/templates/cursor/provider.toml",
+      "path": "/v1/templates/cursor/provider.toml",
       "checksums": {
         "provider.toml": "cd6086deb334f44a7e7a517e9fb2c95e0117d98394d20d29c42384eb06b0b139",
         "command.hbs": "a57a93257b0307d8c97fa5b41739a2922fe908e8556b050567cf52332c1019aa",
@@ -90,7 +90,7 @@
       }
     },
     "deepagents": {
-      "path": "/templates/deepagents/provider.toml",
+      "path": "/v1/templates/deepagents/provider.toml",
       "checksums": {
         "provider.toml": "ed73783f1bd7f6f698ffbf6a97617474232d9eef0ef040382b47c70516d5f42a",
         "instruction.hbs": "2e5f4276873f08ba55892221e2618667b28da8bb216452b82628fd56315f0d67",
@@ -99,7 +99,7 @@
       }
     },
     "factory-droid": {
-      "path": "/templates/factory-droid/provider.toml",
+      "path": "/v1/templates/factory-droid/provider.toml",
       "checksums": {
         "provider.toml": "533d23292ac2662f34f4ec21eb9716a71112772ce52bdfe441d6ca433b8fef82",
         "command.hbs": "a57a93257b0307d8c97fa5b41739a2922fe908e8556b050567cf52332c1019aa",
@@ -109,7 +109,7 @@
       }
     },
     "gemini": {
-      "path": "/templates/gemini/provider.toml",
+      "path": "/v1/templates/gemini/provider.toml",
       "checksums": {
         "provider.toml": "e4ca0e09c874f4aafdb6704e90aa631e7bf5d12b07727b62e4365c7dd8d3d0ab",
         "command.hbs": "009ad4a010c91f439c62ea47cd5fcc71d276d100bb9174b79d56bb4c3b7b6df3",
@@ -119,7 +119,7 @@
       }
     },
     "goose": {
-      "path": "/templates/goose/provider.toml",
+      "path": "/v1/templates/goose/provider.toml",
       "checksums": {
         "provider.toml": "05a23f9bfadbf6da2c62a45beef1f3d37c23d7504b641651011f8406f87613a4",
         "command.hbs": "27da9b4869cfb52fe8ac303b4e80b0146e094f123a92f670b96eb9614c403fd4",
@@ -129,7 +129,7 @@
       }
     },
     "junie": {
-      "path": "/templates/junie/provider.toml",
+      "path": "/v1/templates/junie/provider.toml",
       "checksums": {
         "provider.toml": "f7c4cd85883a2fb6fbd2964c6fd0e096811681e5f38df6e8f3522e0accab60f9",
         "command.hbs": "3f95b9b1855ef17ac91feeaccb3d33d989aa81126a7b5804bbe4b074ef0f5dd6",
@@ -139,7 +139,7 @@
       }
     },
     "kilocode": {
-      "path": "/templates/kilocode/provider.toml",
+      "path": "/v1/templates/kilocode/provider.toml",
       "checksums": {
         "provider.toml": "cb290995ef24404334129773cc3daabf3688fb49cc4983dc2e8cfd8c4b93632b",
         "command.hbs": "3f95b9b1855ef17ac91feeaccb3d33d989aa81126a7b5804bbe4b074ef0f5dd6",
@@ -149,7 +149,7 @@
       }
     },
     "kimi": {
-      "path": "/templates/kimi/provider.toml",
+      "path": "/v1/templates/kimi/provider.toml",
       "checksums": {
         "provider.toml": "e65ab72f71c3c11e1def0344ec30021149c13fd0b5771ae30436fded2cb7136b",
         "instruction.hbs": "2e5f4276873f08ba55892221e2618667b28da8bb216452b82628fd56315f0d67",
@@ -158,7 +158,7 @@
       }
     },
     "mistral-vibe": {
-      "path": "/templates/mistral-vibe/provider.toml",
+      "path": "/v1/templates/mistral-vibe/provider.toml",
       "checksums": {
         "provider.toml": "b7320f3701f60fec82d01589beef887ac6653a126c0edbef12f4758dc7a27dc4",
         "instruction.hbs": "2e5f4276873f08ba55892221e2618667b28da8bb216452b82628fd56315f0d67",
@@ -167,7 +167,7 @@
       }
     },
     "opencode": {
-      "path": "/templates/opencode/provider.toml",
+      "path": "/v1/templates/opencode/provider.toml",
       "checksums": {
         "provider.toml": "2fe2c1b015072df71995abed9fed970b98c8e8cdfeaf970cf120c914b47068fd",
         "command.hbs": "3f95b9b1855ef17ac91feeaccb3d33d989aa81126a7b5804bbe4b074ef0f5dd6",
@@ -177,7 +177,7 @@
       }
     },
     "pi": {
-      "path": "/templates/pi/provider.toml",
+      "path": "/v1/templates/pi/provider.toml",
       "checksums": {
         "provider.toml": "9dcc4823441052dfea808032e002059151179faff2ed339797479f8fd894485d",
         "command.hbs": "3f95b9b1855ef17ac91feeaccb3d33d989aa81126a7b5804bbe4b074ef0f5dd6",
@@ -185,7 +185,7 @@
       }
     },
     "qoder-cli": {
-      "path": "/templates/qoder-cli/provider.toml",
+      "path": "/v1/templates/qoder-cli/provider.toml",
       "checksums": {
         "provider.toml": "6cf4153cc877911093dabe378c6d56a5a09f99356bb06cce4155b58fa1332d2c",
         "command.hbs": "6650ba27e033d911b3ea2dd264c2a5ed1a7724630bc16a08e36d4423c3beb48f",
@@ -195,7 +195,7 @@
       }
     },
     "qwen": {
-      "path": "/templates/qwen/provider.toml",
+      "path": "/v1/templates/qwen/provider.toml",
       "checksums": {
         "provider.toml": "13d9dce3334baeec70244744b83ebc759e3d6bfcfda624050cf2c6816f5f321d",
         "command.hbs": "3f95b9b1855ef17ac91feeaccb3d33d989aa81126a7b5804bbe4b074ef0f5dd6",
@@ -204,21 +204,21 @@
       }
     },
     "roo": {
-      "path": "/templates/roo/provider.toml",
+      "path": "/v1/templates/roo/provider.toml",
       "checksums": {
         "provider.toml": "f21a0e17ad955823d1a95b564c1a96b02db80e468948c8bcb2a94551fb650519",
         "command.hbs": "a57a93257b0307d8c97fa5b41739a2922fe908e8556b050567cf52332c1019aa"
       }
     },
     "shai": {
-      "path": "/templates/shai/provider.toml",
+      "path": "/v1/templates/shai/provider.toml",
       "checksums": {
         "provider.toml": "3de22f74eb2e7bce55ca3122e6b5705b70b5ce1a5d498295dd06c258035dc0c3",
         "command.hbs": "a57a93257b0307d8c97fa5b41739a2922fe908e8556b050567cf52332c1019aa"
       }
     },
     "windsurf": {
-      "path": "/templates/windsurf/provider.toml",
+      "path": "/v1/templates/windsurf/provider.toml",
       "checksums": {
         "provider.toml": "aa9e201770cfb84b019c1925f32d4b04287e9a21f1d70dde7c228fa4234e9db7",
         "command.hbs": "2ff2983122964767e8a8d98702fbaf57d1e392d5e4cbc8d21b9f494f92b90e94",

--- a/public/v1/templates/roo/provider.toml
+++ b/public/v1/templates/roo/provider.toml
@@ -1,4 +1,4 @@
 # Augment Commands
 [providers.roo.commands]
-template = "https://dotagents.soorya-u.dev/templates/roo/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/roo/command.hbs"
 target = "{{dir.workspace}}/.roo/commands/{{command.name}}.md"

--- a/public/v1/templates/shai/provider.toml
+++ b/public/v1/templates/shai/provider.toml
@@ -1,4 +1,4 @@
 # Augment Commands
 [providers.shai.commands]
-template = "https://dotagents.soorya-u.dev/templates/roo/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/roo/command.hbs"
 target = "{{dir.workspace}}/.shai/commands/{{command.name}}.md"

--- a/public/v1/templates/windsurf/provider.toml
+++ b/public/v1/templates/windsurf/provider.toml
@@ -1,9 +1,9 @@
 # Windsurf Instructions
 [providers.windsurf.instructions]
-template = "https://dotagents.soorya-u.dev/templates/windsurf/instruction.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/windsurf/instruction.hbs"
 target = "{{ dir.workspace }}/.windsurf/rules/specify-rules.md"
 
 # Windsurf Commands
 [providers.windsurf.commands]
-template = "https://dotagents.soorya-u.dev/templates/windsurf/command.hbs"
+template = "https://dotagents.soorya-u.dev/v1/templates/windsurf/command.hbs"
 target = "{{ dir.workspace }}/.windsurf/workflows/{{ command.name }}.md"

--- a/scripts/ci/detect_template_changes.sh
+++ b/scripts/ci/detect_template_changes.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-if git diff --name-only HEAD~1 HEAD | grep -q "public/v1/templates/"; then
+changed=$(git diff --name-only HEAD~1 HEAD)
+
+if echo "$changed" | grep -qE "public/v1/templates/|\.github/workflows/generate-registry\.yml|scripts/ci/detect_template_changes\.sh"; then
     echo "changes_detected=true" >> "$GITHUB_OUTPUT"
 else
     echo "changes_detected=false" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/generate_registry.sh
+++ b/scripts/ci/generate_registry.sh
@@ -35,7 +35,7 @@ for d in "$ROOT"/*; do
 
     jq \
       --arg name "$name" \
-      --arg path "/templates/$name/provider.toml" \
+      --arg path "/v1/templates/$name/provider.toml" \
       --argjson checksums "$checksums" \
       '.providers[$name] = { "path": $path, "checksums": $checksums }' \
       "$TMP_FILE" > "${TMP_FILE}.new"

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -122,7 +122,7 @@ pub(super) fn initialize_agents_dir(mut opts: InitOptions) -> Result<()> {
             LOCAL_CONFIG_FILE,
             match template {
                 InitTemplate::WithCustomProvider => mocks::LOCAL_CONFIG_WITH_PROVIDER,
-                InitTemplate::Starter => mocks::LOCAL_CONFIG_STARTER,
+                InitTemplate::Starter => mocks::CONFIG,
             },
         ),
         InitFile::new(INSTRUCTIONS_FILE, mocks::INSTRUCTIONS)
@@ -175,15 +175,12 @@ pub(super) fn initialize_agents_dir(mut opts: InitOptions) -> Result<()> {
             continue;
         }
         write_file(&main_dir.join(&file.path), file.content)?;
-        if tui_mode {
-            ui::init::show_file_written(&file.path.display().to_string());
-        }
     }
 
     if tui_mode {
-        let targets = ui::init::prompt_targets()?;
-        if !targets.is_empty() {
-            update_config_targets(&main_dir.join(GLOBAL_CONFIG_FILE), &targets)?;
+        if !opts.targets.is_empty() {
+            update_config_targets(&main_dir.join(GLOBAL_CONFIG_FILE), &opts.targets)?;
+            update_config_targets(&main_dir.join(LOCAL_CONFIG_FILE), &opts.targets)?;
         }
         ui::init::finish_init();
     }
@@ -204,6 +201,7 @@ mod tests {
             no_skill: false,
             force: false,
             template: None,
+            targets: vec![],
         }
     }
 

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -127,6 +127,10 @@ pub(crate) struct InitOptions {
     /// When omitted in an interactive terminal, the wizard will prompt for a choice.
     #[clap(long, value_enum)]
     pub template: Option<InitTemplate>,
+
+    /// Provider targets selected interactively by the wizard; not a CLI flag.
+    #[clap(skip)]
+    pub targets: Vec<String>,
 }
 
 pub fn get_options() -> Options {
@@ -165,6 +169,7 @@ mod tests {
             no_skill: false,
             force: false,
             template: None,
+            targets: vec![],
         };
 
         assert!(!init_options.no_mcp);

--- a/src/cli/ui/init.rs
+++ b/src/cli/ui/init.rs
@@ -27,16 +27,12 @@ pub(crate) fn run_init_wizard(opts: &mut InitOptions, dir_exists: bool) -> Resul
     let mut ms = multiselect("Which features do you want to enable?")
         .item(
             "commands",
-            "commands",
+            "Custom Commands",
             "Sync slash commands to your AI tools",
         )
-        .item(
-            "instructions",
-            "instructions",
-            "Sync a global INSTRUCTIONS.md",
-        )
-        .item("mcp", "mcp", "Sync MCP server configuration")
-        .item("skills", "skills", "Sync skills (experimental)")
+        .item("instructions", "AGENTS.md", "Sync a global AGENTS.md")
+        .item("mcp", "MCP Configuration", "Sync MCP server configuration")
+        .item("skills", "Skills", "Sync skills")
         .initial_values(vec!["commands", "instructions", "mcp", "skills"])
         .required(false);
     let features = ms.interact().context("Failed to get feature selection")?;
@@ -52,17 +48,15 @@ pub(crate) fn run_init_wizard(opts: &mut InitOptions, dir_exists: bool) -> Resul
         .item(
             InitTemplate::WithCustomProvider,
             "With Custom Provider",
-            "Adds a mycode example provider",
+            "Adds an example of a custom provider",
         );
     let template = ts.interact().context("Failed to get template choice")?;
     opts.template = Some(template);
 
-    Ok(true)
-}
+    // Provider selection — runs before files are written so targets are known upfront.
+    opts.targets = prompt_targets()?;
 
-/// Logs a file-written step line inside the active wizard session.
-pub(crate) fn show_file_written(relative_path: &str) {
-    cliclack::log::step(format!("wrote {}", relative_path)).ok();
+    Ok(true)
 }
 
 /// Fetches the provider registry and prompts the user to select deployment targets.

--- a/src/constants/mocks.rs
+++ b/src/constants/mocks.rs
@@ -5,7 +5,6 @@ pub const INSTRUCTIONS: &str = include_str!("../mocks/INSTRUCTIONS.md");
 pub const COMMAND_HELLO: &str = include_str!("../mocks/commands/hello.md");
 pub const SKILL_HELLO: &str = include_str!("../mocks/skills/hello-skill/SKILL.md");
 pub const CONFIG: &str = include_str!("../mocks/config.toml");
-pub const LOCAL_CONFIG_STARTER: &str = include_str!("../mocks/local.config.starter.toml");
 pub const LOCAL_CONFIG_WITH_PROVIDER: &str = include_str!("../mocks/local.config.toml");
 pub const MCP: &str = include_str!("../mocks/mcp.jsonc");
 pub const TEMPLATE_MYCODE_COMMAND: &str = include_str!("../mocks/templates/mycode/command.hbs");

--- a/src/mocks/config.toml
+++ b/src/mocks/config.toml
@@ -6,7 +6,4 @@ features = [
     "skills",
 ]
 
-targets = [
-    "windsurf",
-    "gemini",
-]
+targets = []

--- a/src/mocks/local.config.starter.toml
+++ b/src/mocks/local.config.starter.toml
@@ -1,9 +1,0 @@
-schema = "https://dotagents.soorya-u.dev/schemas/config.schema.json"
-features = [
-    "commands",
-    "instructions",
-    "mcp",
-    "skills",
-]
-
-targets = []

--- a/src/mocks/mcp.jsonc
+++ b/src/mocks/mcp.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://dotagents.soorya-u.dev/json/schemas/mcp.schema.json",
+  "$schema": "https://dotagents.soorya-u.dev/v1/schemas/mcp.schema.json",
   "servers": {
     "server-stdio": {
       "type": "stdio",
@@ -7,14 +7,14 @@
       "args": [],
       "cwd": "{{ dir.workspace }}",
       "env": {},
-      "env_file": null,
+      "env_file": null
     },
     "server-mcp": {
       "type": "http",
       "url": "http://localhost:9000",
       "headers": {
-        "Authorization": "Bearer ${API_KEY}",
-      },
-    },
-  },
+        "Authorization": "Bearer ${API_KEY}"
+      }
+    }
+  }
 }

--- a/src/templates/registry_resolver.rs
+++ b/src/templates/registry_resolver.rs
@@ -135,6 +135,38 @@ pub(crate) fn resolve_provider_defaults(
             continue;
         }
 
+        // Skip the network fetch entirely when every active feature is already fully configured.
+        let needs_any = all_features.iter().any(|f| {
+            if !app_config.has_feature(f) {
+                return false;
+            }
+            let s = app_config
+                .providers
+                .as_ref()
+                .and_then(|p| p.0.as_ref())
+                .and_then(|m| m.get(&provider_name))
+                .and_then(|fs| fs.get_config(f));
+            s.is_none_or(|s| s.template.is_none() || s.target.is_none())
+        });
+        if !needs_any {
+            continue;
+        }
+
+        // Fetch provider.toml once for all features so the warning fires at most once per provider.
+        let toml_content =
+            match get_provider_toml(&provider_name, registry, cache, offline, no_cache) {
+                Ok(Some(c)) => c,
+                Ok(None) => continue,
+                Err(e) if offline => return Err(e),
+                Err(e) => {
+                    warn!(
+                        "Failed to fetch provider.toml for provider '{}': {}",
+                        &provider_name, e
+                    );
+                    continue;
+                }
+            };
+
         for feature in &all_features {
             if !app_config.has_feature(feature) {
                 continue;
@@ -156,9 +188,15 @@ pub(crate) fn resolve_provider_defaults(
             }
 
             // Attempt resolution; propagate as hard error only in --offline mode.
-            match resolve_for_provider(&provider_name, feature, registry, cache, offline, no_cache)
-            {
-                Ok(None) => continue, // warning already emitted inside
+            match resolve_for_provider(
+                &provider_name,
+                feature,
+                &toml_content,
+                registry,
+                cache,
+                no_cache,
+            ) {
+                Ok(None) => continue,
                 Ok(Some(resolved)) => {
                     // Merge: user-config takes priority over resolved defaults.
                     let merged = existing
@@ -177,24 +215,17 @@ pub(crate) fn resolve_provider_defaults(
     Ok(())
 }
 
-/// Resolves a single (provider, feature) pair from the registry/cache, returning `None` when the provider/feature should be skipped.
+/// Resolves a single (provider, feature) pair from pre-fetched `toml_content`, returning `None` when the feature should be skipped.
 fn resolve_for_provider(
     provider: &str,
     feature: &Feature,
+    toml_content: &str,
     registry: Option<&Registry>,
     cache: &TemplateCache,
-    offline: bool,
     no_cache: bool,
 ) -> Result<Option<FeatureSettings>> {
-    // Step 1: obtain provider.toml content.
-    let toml_content = get_provider_toml(provider, registry, cache, offline, no_cache)?;
-    let toml_content = match toml_content {
-        Some(c) => c,
-        None => return Ok(None),
-    };
-
-    // Step 2: parse and extract the feature settings.
-    let mut feature_settings = match parse_provider_toml(&toml_content, provider, feature)? {
+    // Step 1: parse and extract the feature settings.
+    let mut feature_settings = match parse_provider_toml(toml_content, provider, feature)? {
         Some(s) => s,
         None => {
             warn!(


### PR DESCRIPTION
- Update all template URLs and registry paths to /v1/templates/ for API versioning
- Integrate target selection into init wizard flow instead of separate prompt
- Simplify starter config by reusing global config template
- Remove per-file UI notifications, consolidate to init completion screen
- Update CI scripts and GH Actions to detect and generate /v1/ paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced initialization wizard with clearer feature labels ("Custom Commands," "MCP Configuration," "Skills") and streamlined provider target selection.
  * Updated template infrastructure to use versioned API endpoints across all providers.
  * Optimized template resolver to reduce unnecessary configuration lookups during initialization.

* **Chores**
  * Updated CI workflows and template change detection scripts for improved registry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->