### PR TITLE
Add OpenSpec proposals for CI, release pipeline, and test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/target
-.dotagents-debug
-.mycode
+target/
 tests/e2e/node_modules/
 tests/e2e/.tui-test/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "dotagents"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotagents"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Soorya U <sooryau7@gmail.com>"]
 description = "An agent configuration manager and templater written in rust"
 repository = "https://github.com/soorya-u/dotagents"

--- a/openspec/changes/add-pr-ci/.openspec.yaml
+++ b/openspec/changes/add-pr-ci/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/add-pr-ci/design.md
+++ b/openspec/changes/add-pr-ci/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The repo has one existing workflow (`generate-registry.yml`) that runs on pushes to `main` affecting `public/v1/templates/**`. No workflow runs on pull requests or on general code changes. The local developer workflow uses `mise check` (fmt + clippy) and `mise tests` (unit + integration + e2e), but nothing enforces this in CI. The Rust toolchain is pinned to `1.92` via `mise.toml`; the TypeScript e2e suite uses Bun `1.3`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Block merging PRs that have fmt violations, clippy warnings, failing unit/integration tests, or platform compile errors
+- Keep PR CI fast — all jobs run in parallel, no sequential dependencies
+- Pin the exact same Rust version in CI as in local dev (`mise.toml`)
+- Verify the crate is publishable on every PR via `--dry-run`
+
+**Non-Goals:**
+- Running e2e tests on PRs (slow, requires release binary — reserved for release pipeline)
+- Auto-fixing formatting (CI checks only, never mutates)
+- Setting up branch protection rules (done manually in GitHub settings)
+- Caching Bun packages (minimal gain for `bunx biome check`)
+
+## Decisions
+
+**`dtolnay/rust-toolchain@1.92` over `rustup update`**
+The reference project uses `rustup update` (latest stable). We pin to `1.92` to match `mise.toml` exactly — using latest stable in CI would mean CI and local could silently diverge. `dtolnay/rust-toolchain` is the standard action for pinning.
+
+**`cargo check` (not `cargo build`) for the cross-platform matrix**
+`cargo build` produces a binary but takes significantly longer. `cargo check` performs full type-checking and catches all compile errors without linking — sufficient to validate platform compatibility. Tests only run on ubuntu-latest where we have a consistent environment.
+
+**`--locked` on all cargo commands**
+Ensures `Cargo.lock` is always respected in CI. Without `--locked`, Cargo may silently update dependencies on a cache miss, making CI non-deterministic.
+
+**`fail-fast: false` on the platform matrix**
+With `fail-fast: true` (default), a Windows compile failure would cancel the macOS jobs mid-run, hiding additional errors. Seeing all four platform results on every run is more useful for diagnosis.
+
+**Five separate jobs over one job with sequential steps**
+Independent jobs run in parallel on GitHub Actions. A fmt failure doesn't block the test job from running — developers see all failures at once rather than fixing one gate at a time.
+
+**`cargo publish --dry-run` as a separate job**
+Catches stale `include`/`exclude` patterns in `Cargo.toml` and missing files before they become a real publish failure. Costs one extra runner but saves a broken release.
+
+## Risks / Trade-offs
+
+- [musl target on ubuntu-latest requires `musl-tools`] → Add `sudo apt-get install -y musl-tools` step before `cargo check` in the ubuntu musl matrix leg
+- [check-publish may fail if `Cargo.lock` is excluded from the published crate] → Verify `Cargo.toml` publish settings; `--dry-run` will surface this immediately
+- [Windows cargo check may be slower than other platforms] → Acceptable; `fail-fast: false` means it doesn't block other jobs

--- a/openspec/changes/add-pr-ci/design.md
+++ b/openspec/changes/add-pr-ci/design.md
@@ -18,6 +18,9 @@ The repo has one existing workflow (`generate-registry.yml`) that runs on pushes
 
 ## Decisions
 
+**This proposal is independent of all other open proposals**
+`add-pr-ci`, `add-release-pipeline`, `fix-mock-files`, `fix-init-dir-timing`, `fix-e2e-release-build`, and `fix-error-handling` have no blocking dependencies on each other and can be implemented in any order. The `implement-skills` proposal is archived at `openspec/changes/archive/2026-04-25-implement-skills/` and is not a dependency.
+
 **`dtolnay/rust-toolchain@1.92` over `rustup update`**
 The reference project uses `rustup update` (latest stable). We pin to `1.92` to match `mise.toml` exactly — using latest stable in CI would mean CI and local could silently diverge. `dtolnay/rust-toolchain` is the standard action for pinning.
 

--- a/openspec/changes/add-pr-ci/proposal.md
+++ b/openspec/changes/add-pr-ci/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Every pull request to `dotagents` currently merges without any automated check — no formatting, no lint, no tests. The only CI workflow in the repo (`generate-registry.yml`) runs only on template changes, not on code changes. This means broken Rust code, clippy warnings, and failing tests can all land on `main` silently.
+
+## What Changes
+
+- Add `.github/workflows/ci.yml` with five parallel jobs that gate every PR and push to `main`:
+  - **fmt** — enforces `cargo fmt` (read-only check, not auto-fix) and `biome check` on the TypeScript e2e suite
+  - **clippy** — runs `cargo clippy --locked -- -D warnings` (warnings are hard errors)
+  - **test** — runs unit tests (`cargo test --bin dotagents`) and integration tests (`cargo test --test integration`); e2e is excluded from PR CI and reserved for the release pipeline
+  - **check** — compiles the binary for all four target platforms (Linux musl, macOS x86, macOS arm64, Windows msvc) to catch platform-specific compile errors without running tests on every PR
+  - **check-publish** — runs `cargo publish --dry-run` to catch missing files or bad Cargo metadata before a real release
+
+## Capabilities
+
+### New Capabilities
+
+- `pr-ci`: Defines the automated checks that must pass on every pull request before code reaches `main`.
+
+### Modified Capabilities
+
+*(none)*
+
+## Impact
+
+- `.github/workflows/ci.yml` — new file
+- No changes to source code, `Cargo.toml`, or `mise.toml`
+- Requires no new secrets — `GITHUB_TOKEN` is auto-provided

--- a/openspec/changes/add-pr-ci/specs/pr-ci/spec.md
+++ b/openspec/changes/add-pr-ci/specs/pr-ci/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: CI runs on every pull request and push to main
+The CI workflow SHALL trigger automatically on every pull request (any branch) and on every push to the `main` branch.
+
+#### Scenario: PR opened triggers CI
+- **WHEN** a pull request is opened or updated against any branch
+- **THEN** all five CI jobs start automatically within GitHub Actions
+
+#### Scenario: Push to main triggers CI
+- **WHEN** a commit is pushed directly to `main`
+- **THEN** all five CI jobs start automatically
+
+### Requirement: Formatting is enforced as a hard gate
+The CI workflow SHALL fail if Rust source is not formatted per `rustfmt` or if TypeScript e2e source has biome violations. Formatting MUST be checked read-only — CI SHALL NOT auto-fix code.
+
+#### Scenario: Unformatted Rust fails CI
+- **WHEN** a PR contains Rust source not conforming to `rustfmt` output
+- **THEN** the `fmt` job exits non-zero and the PR is blocked
+
+#### Scenario: Biome violation fails CI
+- **WHEN** a PR contains TypeScript in `tests/e2e/` that fails `biome check`
+- **THEN** the `fmt` job exits non-zero and the PR is blocked
+
+#### Scenario: Correctly formatted code passes
+- **WHEN** all Rust and TypeScript source passes their respective format checks
+- **THEN** the `fmt` job exits zero
+
+### Requirement: Clippy warnings are treated as errors
+The CI workflow SHALL fail if `cargo clippy` reports any warning when run with `-- -D warnings`.
+
+#### Scenario: Clippy warning blocks PR
+- **WHEN** a PR introduces a Rust pattern that triggers a clippy lint
+- **THEN** the `clippy` job exits non-zero and the PR is blocked
+
+#### Scenario: Clean clippy output passes
+- **WHEN** no clippy warnings are present
+- **THEN** the `clippy` job exits zero
+
+### Requirement: Unit and integration tests must pass
+The CI workflow SHALL run `cargo test --bin dotagents` and `cargo test --test integration` and fail if either exits non-zero. E2E tests SHALL NOT run in PR CI.
+
+#### Scenario: Failing unit test blocks PR
+- **WHEN** a PR causes any unit test in the binary to fail
+- **THEN** the `test` job exits non-zero and the PR is blocked
+
+#### Scenario: Failing integration test blocks PR
+- **WHEN** a PR causes any integration test to fail
+- **THEN** the `test` job exits non-zero and the PR is blocked
+
+#### Scenario: E2E tests are not run
+- **WHEN** CI runs on a PR
+- **THEN** no e2e test process is started (tui-test is not invoked)
+
+### Requirement: Binary must compile on all four target platforms
+The CI workflow SHALL verify the binary compiles (via `cargo check`) on `x86_64-pc-windows-msvc`, `x86_64-unknown-linux-musl`, `x86_64-apple-darwin`, and `aarch64-apple-darwin`. A failure on one platform SHALL NOT cancel checks on others.
+
+#### Scenario: Platform compile error is caught
+- **WHEN** a PR introduces platform-specific code that fails to compile on one target
+- **THEN** the `check` job leg for that target exits non-zero
+- **THEN** the remaining three platform legs continue running
+
+#### Scenario: All platforms compile successfully
+- **WHEN** the code compiles cleanly on all four targets
+- **THEN** all four `check` matrix legs exit zero
+
+### Requirement: Crate must be publishable on every PR
+The CI workflow SHALL run `cargo publish --dry-run --locked` and fail if the crate cannot be published, catching missing files or invalid metadata before a real release.
+
+#### Scenario: Missing file in published crate fails CI
+- **WHEN** a file referenced in `Cargo.toml` is absent or excluded from the publish set
+- **THEN** the `check-publish` job exits non-zero
+
+#### Scenario: Valid crate metadata passes
+- **WHEN** `Cargo.toml` metadata is complete and all included files are present
+- **THEN** the `check-publish` job exits zero

--- a/openspec/changes/add-pr-ci/specs/pr-ci/spec.md
+++ b/openspec/changes/add-pr-ci/specs/pr-ci/spec.md
@@ -1,5 +1,7 @@
 ## ADDED Requirements
 
+> **Note:** This proposal is independent of all other open proposals (`add-release-pipeline`, `fix-mock-files`, `fix-init-dir-timing`, `fix-e2e-release-build`, `fix-error-handling`). The `implement-skills` proposal is archived at `openspec/changes/archive/2026-04-25-implement-skills/` and is not a dependency or prerequisite.
+
 ### Requirement: CI runs on every pull request and push to main
 The CI workflow SHALL trigger automatically on every pull request (any branch) and on every push to the `main` branch.
 

--- a/openspec/changes/add-pr-ci/tasks.md
+++ b/openspec/changes/add-pr-ci/tasks.md
@@ -1,0 +1,39 @@
+## 1. Create workflow file scaffold
+
+- [ ] 1.1 Create `.github/workflows/ci.yml` with the trigger block: `on: pull_request` and `on: push: branches: [main]`
+- [ ] 1.2 Add `rust-toolchain.toml` to the repo root pinning `channel = "1.92"` so the toolchain pin is also explicit outside CI
+
+## 2. Add fmt job
+
+- [ ] 2.1 Add `fmt` job to `ci.yml` running on `ubuntu-latest` with steps: `actions/checkout@v4`, `dtolnay/rust-toolchain@1.92`, `oven-sh/setup-bun@v2`, `Swatinem/rust-cache@v2`
+- [ ] 2.2 Add step: `cargo fmt --all -- --check`
+- [ ] 2.3 Add step: `cd tests/e2e && bunx biome check .`
+
+## 3. Add clippy job
+
+- [ ] 3.1 Add `clippy` job running on `ubuntu-latest` with steps: `actions/checkout@v4`, `dtolnay/rust-toolchain@1.92` (with `components: clippy`), `Swatinem/rust-cache@v2`
+- [ ] 3.2 Add step: `cargo clippy --locked -- -D warnings`
+
+## 4. Add test job
+
+- [ ] 4.1 Add `test` job running on `ubuntu-latest` with steps: `actions/checkout@v4`, `dtolnay/rust-toolchain@1.92`, `Swatinem/rust-cache@v2`
+- [ ] 4.2 Add step: `cargo test --bin dotagents --locked`
+- [ ] 4.3 Add step: `cargo test --test integration --locked`
+
+## 5. Add cross-platform check job
+
+- [ ] 5.1 Add `check` job with `strategy.fail-fast: false` and matrix of four entries: `windows-latest/x86_64-pc-windows-msvc`, `ubuntu-latest/x86_64-unknown-linux-musl`, `macos-latest/x86_64-apple-darwin`, `macos-latest/aarch64-apple-darwin`
+- [ ] 5.2 Add step: `rustup target add ${{ matrix.target }}`
+- [ ] 5.3 Add step for the musl leg only: `sudo apt-get install -y musl-tools` (use `if: matrix.target == 'x86_64-unknown-linux-musl'`)
+- [ ] 5.4 Add step: `cargo check --verbose --locked --target ${{ matrix.target }}`
+
+## 6. Add check-publish job
+
+- [ ] 6.1 Add `check-publish` job running on `ubuntu-latest` with steps: `actions/checkout@v4`, `dtolnay/rust-toolchain@1.92`, `Swatinem/rust-cache@v2`
+- [ ] 6.2 Add step: `cargo publish --dry-run --verbose --locked`
+
+## 7. Verification
+
+- [ ] 7.1 Open a draft PR against `main` and confirm all five jobs appear in the Actions tab and pass
+- [ ] 7.2 Verify the `check` job shows four separate matrix legs in the GitHub Actions UI
+- [ ] 7.3 Confirm `cargo publish --dry-run` passes locally before merging

--- a/openspec/changes/add-release-pipeline/.openspec.yaml
+++ b/openspec/changes/add-release-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/add-release-pipeline/design.md
+++ b/openspec/changes/add-release-pipeline/design.md
@@ -23,6 +23,12 @@ A single tag-push pipeline (the common pattern) immediately starts building and 
 **Tag-based trigger for Stage 2**
 Stage 1 pushes an annotated tag (`v$VERSION`) after the release PR is merged. Stage 2 triggers on `on: push: tags: 'v*.*.*'`. Alternative considered: filtering `push` to `main` by `startsWith(github.event.head_commit.message, 'chore: release v')` — rejected because commit message matching is fragile (squash merges can reword the title, and any manual push with a matching prefix fires the pipeline unexpectedly). The tag-based approach is the pattern used by widely-deployed Rust tooling (e.g. t3code, cargo-dist) and is unambiguous: a tag only exists if Stage 1 explicitly created it. Another alternative: a dedicated `release/*` branch — adds branch management overhead with no benefit since we already have the PR as the review gate.
 
+**Preflight job gates all build jobs**
+A `preflight` job runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test --locked` on `ubuntu-latest` before any `build-release` matrix leg starts. `build-release` declares `needs: [preflight]`. This prevents burning 5 build runners (including macOS and Windows which consume more minutes) on a commit that fails basic checks. Alternative: skip preflight and let the CI workflow catch it — cheaper in the happy path but wasteful on failures.
+
+**Commits to Homebrew/Scoop repos attributed to `github-actions[bot]`**
+The `update-homebrew` and `update-scoop` jobs set `git config user.name "github-actions[bot]"` and `git config user.email "41898282+github-actions[bot]@users.noreply.github.com"` before committing. GitHub recognizes that email and renders commits with the bot avatar. Authentication uses `RELEASE_PAT` (owned by the repo author) — authorship and auth are separate in git. Alternative: a GitHub App with auto-rotating tokens — more secure, no expiry concern, but requires one-time org-level setup. Current choice: `RELEASE_PAT` with documented expiry reminder, upgrade to GitHub App if PAT rotation becomes painful.
+
 **`cross` crate for linux-arm64-musl**
 `aarch64-unknown-linux-musl` cannot be cross-compiled natively on ubuntu-latest runners without QEMU or a cross-compilation toolchain. `cross` (cargo install cross) provides a Docker-based cross-compilation environment and is the standard approach for this target. Alternative: GitHub's ARM runners — more expensive and overkill for a binary build.
 
@@ -37,7 +43,6 @@ Platform-specific packages (`@dotagents/linux-x64` etc.) each contain only the b
 
 ## Risks / Trade-offs
 
-- [Stage 2 commit title match is fragile] → PR title is set by Stage 1 script exactly as `"chore: release v$VERSION"`; if a developer manually pushes a commit with that prefix, Stage 2 fires unexpectedly → Mitigation: add a version-format check (`grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'`) to abort if the version in `Cargo.toml` doesn't match a semver pattern
 - [cross crate install adds ~60s to linux-arm64 build job] → Acceptable; `Swatinem/rust-cache@v2` caches the `cross` binary after first install
 - [RELEASE_PAT expiry breaks Homebrew/Scoop updates silently] → Document PAT expiry date in repo secrets description; the release job will fail visibly if the PAT is expired
 - [npm publish order matters — platform packages must exist before root shim] → Publish platform packages sequentially before the root package in the publish-npm job script
@@ -49,6 +54,7 @@ Platform-specific packages (`@dotagents/linux-x64` etc.) each contain only the b
 3. Add `.github/workflows/release-prep.yml` and `.github/workflows/release.yml`
 4. Trigger Stage 1 via `workflow_dispatch` with version `0.1.0` for the first release
 5. Review and merge the generated PR
-6. Verify Stage 2 completes all 7 jobs successfully
+6. Push annotated tag `v0.1.0` to trigger Stage 2
+7. Verify Stage 2 completes all jobs successfully (preflight → build-release → e2e → publish-cargo, publish-npm, update-homebrew, update-scoop)
 
-Rollback: if Stage 2 partially fails after tag creation, delete the tag (`git push --delete origin v{version}`), fix the issue, and re-trigger by pushing a new commit that matches the title pattern.
+Rollback: if Stage 2 partially fails after tag creation, delete the tag (`git push --delete origin v{version}`), fix the issue, and re-trigger by pushing the tag again.

--- a/openspec/changes/add-release-pipeline/design.md
+++ b/openspec/changes/add-release-pipeline/design.md
@@ -1,0 +1,54 @@
+## Context
+
+No release automation exists today. The Rust toolchain is pinned to `1.92` in `mise.toml` but not in a `rust-toolchain.toml`, so CI jobs that don't use mise would float to latest stable. Commits already follow conventional commit format (`feat:`, `fix:`, `chore:`), making CHANGELOG generation via `git-cliff` directly applicable. Two external distribution repos are already scaffolded: `soorya-u/homebrew-dotagents` (with placeholder SHA256 in `Formula/dotagents.rb`) and `soorya-u/scoop-dotagents` (with placeholder SHA256 in `bucket/dotagents.json`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give the developer a mandatory review window (the release PR) before anything reaches a registry
+- Gate all publish jobs behind e2e passing on the actual release binary
+- Automate SHA256 computation and cross-repo formula/manifest updates so no manual steps are needed after merging the release PR
+- Publish to five destinations atomically from a single merge: GitHub Releases, crates.io, npm, Homebrew, Scoop
+
+**Non-Goals:**
+- Submitting to the official `scoop-extras` bucket (future work once the project has traction)
+- Supporting Intel macOS (`x86_64-apple-darwin`) in npm packages — binary is built and uploaded to GitHub releases but the npm shim only auto-installs on platforms with a published package
+- Automated version bump without human review (always goes through a PR)
+
+## Decisions
+
+**Two-stage over single tag-triggered pipeline**
+A single tag-push pipeline (the common pattern) immediately starts building and publishing — there's no window to edit the CHANGELOG before it's attached to a GitHub release. The two-stage model separates "prepare" from "publish": Stage 1 is cheap (just files), Stage 2 only fires after a deliberate merge. Alternative considered: `release-plz` (auto-creates release PRs on every push to main) — rejected because Q4 specified manual dispatch, not automatic.
+
+**Commit title match over a separate `release` branch**
+Stage 2 filters `push` events by checking `startsWith(github.event.head_commit.message, 'chore: release v')`. Alternative: a dedicated `release/*` branch — adds branch management overhead with no benefit since we already have the PR as the review gate.
+
+**`cross` crate for linux-arm64-musl**
+`aarch64-unknown-linux-musl` cannot be cross-compiled natively on ubuntu-latest runners without QEMU or a cross-compilation toolchain. `cross` (cargo install cross) provides a Docker-based cross-compilation environment and is the standard approach for this target. Alternative: GitHub's ARM runners — more expensive and overkill for a binary build.
+
+**e2e gates all publish jobs, runs on linux only**
+e2e tests validate the release binary end-to-end. Running on the `linux-x64-musl` binary is sufficient to catch regressions before publishing. Running e2e on all 5 platforms would require PTY support on Windows and macOS runners — complex and slow. If the Linux binary passes e2e, all publish jobs proceed; failure aborts the entire release.
+
+**Direct push to Homebrew/Scoop repos over opening PRs**
+Opening a PR to the tap/bucket repo on each release would require a human to merge it before the formula is live — defeating the automation goal. Direct push to `main` in both external repos is safe because those repos contain only the formula/manifest (no source code, no risk of breaking changes). Access is controlled via a fine-grained `RELEASE_PAT` scoped to only those two repos.
+
+**npm shim pattern for binary distribution**
+Platform-specific packages (`@dotagents/linux-x64` etc.) each contain only the binary for their platform. The root `dotagents` package's `postinstall` script detects the platform and copies the correct binary to `node_modules/.bin/`. Alternative: `cargo-dist` — handles this automatically but is opinionated about the whole release flow and conflicts with the custom two-stage model. Manual shim gives full control.
+
+## Risks / Trade-offs
+
+- [Stage 2 commit title match is fragile] → PR title is set by Stage 1 script exactly as `"chore: release v$VERSION"`; if a developer manually pushes a commit with that prefix, Stage 2 fires unexpectedly → Mitigation: add a version-format check (`grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'`) to abort if the version in `Cargo.toml` doesn't match a semver pattern
+- [cross crate install adds ~60s to linux-arm64 build job] → Acceptable; `Swatinem/rust-cache@v2` caches the `cross` binary after first install
+- [RELEASE_PAT expiry breaks Homebrew/Scoop updates silently] → Document PAT expiry date in repo secrets description; the release job will fail visibly if the PAT is expired
+- [npm publish order matters — platform packages must exist before root shim] → Publish platform packages sequentially before the root package in the publish-npm job script
+
+## Migration Plan
+
+1. Add `rust-toolchain.toml` and `cliff.toml` to repo root
+2. Configure GitHub secrets: `CRATES_IO_TOKEN`, `NPM_TOKEN`, `RELEASE_PAT`
+3. Add `.github/workflows/release-prep.yml` and `.github/workflows/release.yml`
+4. Trigger Stage 1 via `workflow_dispatch` with version `0.1.0` for the first release
+5. Review and merge the generated PR
+6. Verify Stage 2 completes all 7 jobs successfully
+
+Rollback: if Stage 2 partially fails after tag creation, delete the tag (`git push --delete origin v{version}`), fix the issue, and re-trigger by pushing a new commit that matches the title pattern.

--- a/openspec/changes/add-release-pipeline/design.md
+++ b/openspec/changes/add-release-pipeline/design.md
@@ -20,8 +20,8 @@ No release automation exists today. The Rust toolchain is pinned to `1.92` in `m
 **Two-stage over single tag-triggered pipeline**
 A single tag-push pipeline (the common pattern) immediately starts building and publishing — there's no window to edit the CHANGELOG before it's attached to a GitHub release. The two-stage model separates "prepare" from "publish": Stage 1 is cheap (just files), Stage 2 only fires after a deliberate merge. Alternative considered: `release-plz` (auto-creates release PRs on every push to main) — rejected because Q4 specified manual dispatch, not automatic.
 
-**Commit title match over a separate `release` branch**
-Stage 2 filters `push` events by checking `startsWith(github.event.head_commit.message, 'chore: release v')`. Alternative: a dedicated `release/*` branch — adds branch management overhead with no benefit since we already have the PR as the review gate.
+**Tag-based trigger for Stage 2**
+Stage 1 pushes an annotated tag (`v$VERSION`) after the release PR is merged. Stage 2 triggers on `on: push: tags: 'v*.*.*'`. Alternative considered: filtering `push` to `main` by `startsWith(github.event.head_commit.message, 'chore: release v')` — rejected because commit message matching is fragile (squash merges can reword the title, and any manual push with a matching prefix fires the pipeline unexpectedly). The tag-based approach is the pattern used by widely-deployed Rust tooling (e.g. t3code, cargo-dist) and is unambiguous: a tag only exists if Stage 1 explicitly created it. Another alternative: a dedicated `release/*` branch — adds branch management overhead with no benefit since we already have the PR as the review gate.
 
 **`cross` crate for linux-arm64-musl**
 `aarch64-unknown-linux-musl` cannot be cross-compiled natively on ubuntu-latest runners without QEMU or a cross-compilation toolchain. `cross` (cargo install cross) provides a Docker-based cross-compilation environment and is the standard approach for this target. Alternative: GitHub's ARM runners — more expensive and overkill for a binary build.

--- a/openspec/changes/add-release-pipeline/proposal.md
+++ b/openspec/changes/add-release-pipeline/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+There is no automated release process for `dotagents` — every publish to crates.io, npm, Homebrew, and Scoop would have to be done manually and in the right order, with no safety gate. A two-stage pipeline with a mandatory review PR before anything is published gives a review window, enforces e2e tests on the release binary, and automates the otherwise error-prone cross-registry publish sequence.
+
+## What Changes
+
+- Add `cliff.toml` — git-cliff configuration to generate `CHANGELOG.md` from conventional commits (`feat:`, `fix:`, `chore:` sections)
+- Add `rust-toolchain.toml` — pins `channel = "1.92"` so the toolchain is explicit for all CI jobs
+- Add `.github/workflows/release-prep.yml` — Stage 1: manual `workflow_dispatch` that bumps version, generates CHANGELOG, bundles shell completions, and opens a review PR
+- Add `.github/workflows/release.yml` — Stage 2: triggers on merge of `"chore: release v*"` PR; creates a git tag, builds binaries for 5 platforms, runs e2e, publishes to crates.io + npm, updates the Homebrew formula and Scoop manifest
+- `soorya-u/homebrew-dotagents` repo (already scaffolded) — `Formula/dotagents.rb` updated by pipeline on every release
+- `soorya-u/scoop-dotagents` repo (already scaffolded) — `bucket/dotagents.json` updated by pipeline on every release
+
+## Capabilities
+
+### New Capabilities
+
+- `release-pipeline`: Defines the two-stage release process — what triggers each stage, which registries are published to, what gates publication, and which secrets are required.
+
+### Modified Capabilities
+
+*(none)*
+
+## Impact
+
+- `.github/workflows/release-prep.yml` — new file
+- `.github/workflows/release.yml` — new file
+- `cliff.toml` — new file at repo root
+- `rust-toolchain.toml` — new file at repo root
+- `CHANGELOG.md` — created on first release run
+- External repos: `soorya-u/homebrew-dotagents`, `soorya-u/scoop-dotagents` — updated by pipeline
+- Requires 3 secrets to be configured in GitHub repo settings: `CRATES_IO_TOKEN`, `NPM_TOKEN`, `RELEASE_PAT`
+- `GITHUB_TOKEN` is auto-provided and needs no setup

--- a/openspec/changes/add-release-pipeline/specs/release-pipeline/spec.md
+++ b/openspec/changes/add-release-pipeline/specs/release-pipeline/spec.md
@@ -25,6 +25,18 @@ The `release` workflow SHALL trigger on `push: tags: 'v*.*.*'`. It MUST NOT trig
 - **WHEN** the developer merges the `"chore: release v0.2.0"` PR and pushes the annotated tag `v0.2.0`
 - **THEN** all Stage 2 jobs run: build-release, e2e, publish-cargo, publish-npm, update-homebrew, update-scoop
 
+### Requirement: A preflight job gates all build and publish work
+Stage 2 SHALL run a `preflight` job as the first job. All `build-release` matrix legs SHALL declare `needs: [preflight]` and MUST NOT start if `preflight` fails. `preflight` MUST run `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test --locked`.
+
+#### Scenario: Fmt violation aborts release
+- **WHEN** the tagged commit contains unformatted Rust code
+- **THEN** the `preflight` job exits non-zero
+- **THEN** all `build-release` legs, `e2e`, and all publish jobs are skipped
+
+#### Scenario: Clean commit proceeds to build
+- **WHEN** `preflight` passes fmt, clippy, and tests
+- **THEN** all five `build-release` matrix legs start in parallel
+
 ### Requirement: E2E tests must pass before any registry publish
 All publish jobs (crates.io, npm) SHALL declare `needs: e2e` and MUST NOT start if the `e2e` job exits non-zero. The `e2e` job MUST use the actual release binary built in the `build-release` job.
 

--- a/openspec/changes/add-release-pipeline/specs/release-pipeline/spec.md
+++ b/openspec/changes/add-release-pipeline/specs/release-pipeline/spec.md
@@ -14,16 +14,16 @@ A developer SHALL be able to trigger a release preparation by running the `relea
 - **WHEN** the `release-prep` workflow completes
 - **THEN** no package is published to crates.io, npm, Homebrew, or Scoop
 
-### Requirement: Stage 2 only triggers on release PR merges
-The `release` workflow SHALL trigger on push to `main` but MUST exit early without doing any work if the merge commit title does not match the pattern `"chore: release v*"`.
+### Requirement: Stage 2 only triggers on an explicit version tag push
+The `release` workflow SHALL trigger on `push: tags: 'v*.*.*'`. It MUST NOT trigger on branch pushes. The tag is created and pushed manually by the developer after the release PR is merged.
 
-#### Scenario: Non-release push is ignored
+#### Scenario: Non-tag push does not trigger Stage 2
 - **WHEN** a regular feature commit is pushed to `main`
-- **THEN** the `release` workflow starts but exits in the first step without creating a tag or building any binary
+- **THEN** the `release` workflow is not started at all
 
-#### Scenario: Release PR merge triggers full pipeline
-- **WHEN** the `"chore: release v0.2.0"` PR is merged to `main`
-- **THEN** all Stage 2 jobs run: tag, build-release, e2e, publish-cargo, publish-npm, update-homebrew, update-scoop
+#### Scenario: Tag push triggers full pipeline
+- **WHEN** the developer merges the `"chore: release v0.2.0"` PR and pushes the annotated tag `v0.2.0`
+- **THEN** all Stage 2 jobs run: build-release, e2e, publish-cargo, publish-npm, update-homebrew, update-scoop
 
 ### Requirement: E2E tests must pass before any registry publish
 All publish jobs (crates.io, npm) SHALL declare `needs: e2e` and MUST NOT start if the `e2e` job exits non-zero. The `e2e` job MUST use the actual release binary built in the `build-release` job.
@@ -39,7 +39,7 @@ All publish jobs (crates.io, npm) SHALL declare `needs: e2e` and MUST NOT start 
 - **THEN** `publish-cargo` and `publish-npm` jobs start
 
 ### Requirement: Homebrew and Scoop are updated with correct SHA256 on every release
-The `update-homebrew` and `update-scoop` jobs SHALL compute the SHA256 of the released binaries and push updated formula/manifest files to their respective repos. These jobs SHALL run after `build-release` and MUST NOT require e2e to pass first.
+The `update-homebrew` and `update-scoop` jobs SHALL compute the SHA256 of the released binaries and push updated formula/manifest files to their respective repos. These jobs SHALL declare `needs: [build-release, e2e]` — they MUST NOT start if e2e fails, to avoid pushing a formula that points to a broken binary.
 
 #### Scenario: Homebrew formula is updated
 - **WHEN** `build-release` completes and macOS binaries are available on the GitHub release
@@ -52,7 +52,14 @@ The `update-homebrew` and `update-scoop` jobs SHALL compute the SHA256 of the re
 - **THEN** the commit is pushed directly to `main` of `soorya-u/scoop-dotagents`
 
 ### Requirement: All required secrets must be documented by name
-The pipeline MUST document the four required secrets by exact name so any developer can configure them. The pipeline MUST fail with a clear error (not silently skip) if a required secret is absent.
+The pipeline MUST document the following secrets by exact name so any developer can configure them. The pipeline MUST fail with a clear error (not silently skip) if a required secret is absent.
+
+| Secret | Required by | How to obtain |
+|---|---|---|
+| `GITHUB_TOKEN` | All jobs | Auto-provided by GitHub Actions — no setup needed |
+| `CRATES_IO_TOKEN` | `publish-cargo` | crates.io → Account Settings → API Tokens |
+| `NPM_TOKEN` | `publish-npm` | npmjs.com → Access Tokens → Automation token |
+| `RELEASE_PAT` | `update-homebrew`, `update-scoop` | Fine-grained PAT with Contents read+write on `soorya-u/homebrew-dotagents` and `soorya-u/scoop-dotagents` |
 
 #### Scenario: Missing CRATES_IO_TOKEN fails publish-cargo visibly
 - **WHEN** `CRATES_IO_TOKEN` is not set in repository secrets

--- a/openspec/changes/add-release-pipeline/specs/release-pipeline/spec.md
+++ b/openspec/changes/add-release-pipeline/specs/release-pipeline/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Stage 1 creates a reviewable release PR via manual dispatch
+A developer SHALL be able to trigger a release preparation by running the `release-prep` workflow with a version string input. The workflow MUST open a pull request containing the version bump, updated CHANGELOG, and bundled shell completions — and MUST NOT publish anything to any registry.
+
+#### Scenario: Dispatch opens release PR
+- **WHEN** a developer triggers `release-prep` workflow with input version `"0.2.0"`
+- **THEN** `Cargo.toml` version is bumped to `0.2.0`
+- **THEN** `CHANGELOG.md` is prepended with a new section for `v0.2.0` generated from conventional commits since the last tag
+- **THEN** shell completions (bash, elvish, fish, powershell, zsh) are generated and zipped as `completions.zip`
+- **THEN** a PR titled exactly `"chore: release v0.2.0"` is opened containing all changed files
+
+#### Scenario: Stage 1 does not publish
+- **WHEN** the `release-prep` workflow completes
+- **THEN** no package is published to crates.io, npm, Homebrew, or Scoop
+
+### Requirement: Stage 2 only triggers on release PR merges
+The `release` workflow SHALL trigger on push to `main` but MUST exit early without doing any work if the merge commit title does not match the pattern `"chore: release v*"`.
+
+#### Scenario: Non-release push is ignored
+- **WHEN** a regular feature commit is pushed to `main`
+- **THEN** the `release` workflow starts but exits in the first step without creating a tag or building any binary
+
+#### Scenario: Release PR merge triggers full pipeline
+- **WHEN** the `"chore: release v0.2.0"` PR is merged to `main`
+- **THEN** all Stage 2 jobs run: tag, build-release, e2e, publish-cargo, publish-npm, update-homebrew, update-scoop
+
+### Requirement: E2E tests must pass before any registry publish
+All publish jobs (crates.io, npm) SHALL declare `needs: e2e` and MUST NOT start if the `e2e` job exits non-zero. The `e2e` job MUST use the actual release binary built in the `build-release` job.
+
+#### Scenario: E2E failure aborts publish
+- **WHEN** any e2e test fails on the release binary
+- **THEN** the `e2e` job exits non-zero
+- **THEN** `publish-cargo` and `publish-npm` jobs are skipped
+- **THEN** no version is published to crates.io or npm
+
+#### Scenario: E2E pass allows publish
+- **WHEN** all e2e tests pass on the `linux-x64-musl` release binary
+- **THEN** `publish-cargo` and `publish-npm` jobs start
+
+### Requirement: Homebrew and Scoop are updated with correct SHA256 on every release
+The `update-homebrew` and `update-scoop` jobs SHALL compute the SHA256 of the released binaries and push updated formula/manifest files to their respective repos. These jobs SHALL run after `build-release` and MUST NOT require e2e to pass first.
+
+#### Scenario: Homebrew formula is updated
+- **WHEN** `build-release` completes and macOS binaries are available on the GitHub release
+- **THEN** `Formula/dotagents.rb` in `soorya-u/homebrew-dotagents` is updated with the new version and correct SHA256 for both `aarch64-apple-darwin` and `x86_64-apple-darwin`
+- **THEN** the commit is pushed directly to `main` of `soorya-u/homebrew-dotagents`
+
+#### Scenario: Scoop manifest is updated
+- **WHEN** `build-release` completes and the Windows binary is available on the GitHub release
+- **THEN** `bucket/dotagents.json` in `soorya-u/scoop-dotagents` is updated with the new version and correct SHA256 for `x86_64-pc-windows-msvc`
+- **THEN** the commit is pushed directly to `main` of `soorya-u/scoop-dotagents`
+
+### Requirement: All required secrets must be documented by name
+The pipeline MUST document the four required secrets by exact name so any developer can configure them. The pipeline MUST fail with a clear error (not silently skip) if a required secret is absent.
+
+#### Scenario: Missing CRATES_IO_TOKEN fails publish-cargo visibly
+- **WHEN** `CRATES_IO_TOKEN` is not set in repository secrets
+- **THEN** the `publish-cargo` job fails with a cargo authentication error
+- **THEN** the failure is visible in the GitHub Actions run summary
+
+#### Scenario: Missing RELEASE_PAT fails Homebrew/Scoop update visibly
+- **WHEN** `RELEASE_PAT` is not set or is expired
+- **THEN** the `update-homebrew` and `update-scoop` jobs fail with a git push authentication error
+- **THEN** the failure is visible in the GitHub Actions run summary

--- a/openspec/changes/add-release-pipeline/tasks.md
+++ b/openspec/changes/add-release-pipeline/tasks.md
@@ -17,12 +17,12 @@
 - [ ] 3.3 Add step to generate CHANGELOG: `cargo install git-cliff --locked` then `git-cliff --tag v${{ inputs.version }} --prepend CHANGELOG.md`
 - [ ] 3.4 Add step to generate shell completions: build debug binary with `cargo build --locked`, then run `./target/debug/dotagents gen-completions --shell <shell> --to completions/` for each of bash, elvish, fish, powershell, zsh, then `zip -r completions.zip completions/`
 - [ ] 3.5 Add step to open PR using `peter-evans/create-pull-request@v6` with title `"chore: release v${{ inputs.version }}"`, branch `bot/release-v${{ inputs.version }}`, committing `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, `completions.zip`
+- [ ] 3.6 After the PR is merged (handled externally), add a step in a post-merge job or document that the developer must run: create annotated tag `v${{ inputs.version }}` and push it (`git tag -a v$VERSION -m "Release v$VERSION" && git push origin v$VERSION`) — this tag push is what triggers Stage 2
 
 ## 4. Stage 2 — release.yml (tag + build)
 
-- [ ] 4.1 Create `.github/workflows/release.yml` with `on: push: branches: [main]` trigger
-- [ ] 4.2 Add early-exit check as first step of the `tag` job: `if: startsWith(github.event.head_commit.message, 'chore: release v')` condition on the entire job
-- [ ] 4.3 Add `tag` job: extract version from `Cargo.toml` via `grep -m1 '^version' Cargo.toml | cut -d'"' -f2`, create annotated tag `v$VERSION`, push tag using `GITHUB_TOKEN`
+- [ ] 4.1 Create `.github/workflows/release.yml` with `on: push: tags: ['v*.*.*']` trigger
+- [ ] 4.2 Add `tag` job (removed — Stage 1 pushes the tag; Stage 2 triggers directly from it): extract version from the tag ref via `echo "${{ github.ref_name }}" | sed 's/^v//'` and verify it matches `Cargo.toml` version
 - [ ] 4.4 Add `build-release` job (`needs: tag`, `strategy.fail-fast: false`) with matrix: `linux-x64-musl/ubuntu-latest/x86_64-unknown-linux-musl`, `linux-arm64-musl/ubuntu-latest/aarch64-unknown-linux-musl`, `macos-arm64/macos-latest/aarch64-apple-darwin`, `macos-x86/macos-latest/x86_64-apple-darwin`, `windows-x64/windows-latest/x86_64-pc-windows-msvc`
 - [ ] 4.5 In `build-release`: add `cargo install cross --locked` step gated on `matrix.build_name == 'linux-arm64-musl'`; use `cross` for that leg and `cargo` for all others
 - [ ] 4.6 In `build-release`: build with `cargo build --release --locked --verbose --target ${{ matrix.target }}`

--- a/openspec/changes/add-release-pipeline/tasks.md
+++ b/openspec/changes/add-release-pipeline/tasks.md
@@ -19,11 +19,12 @@
 - [ ] 3.5 Add step to open PR using `peter-evans/create-pull-request@v6` with title `"chore: release v${{ inputs.version }}"`, branch `bot/release-v${{ inputs.version }}`, committing `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, `completions.zip`
 - [ ] 3.6 After the PR is merged (handled externally), add a step in a post-merge job or document that the developer must run: create annotated tag `v${{ inputs.version }}` and push it (`git tag -a v$VERSION -m "Release v$VERSION" && git push origin v$VERSION`) — this tag push is what triggers Stage 2
 
-## 4. Stage 2 — release.yml (tag + build)
+## 4. Stage 2 — release.yml (preflight + build)
 
 - [ ] 4.1 Create `.github/workflows/release.yml` with `on: push: tags: ['v*.*.*']` trigger
-- [ ] 4.2 Add `tag` job (removed — Stage 1 pushes the tag; Stage 2 triggers directly from it): extract version from the tag ref via `echo "${{ github.ref_name }}" | sed 's/^v//'` and verify it matches `Cargo.toml` version
-- [ ] 4.4 Add `build-release` job (`needs: tag`, `strategy.fail-fast: false`) with matrix: `linux-x64-musl/ubuntu-latest/x86_64-unknown-linux-musl`, `linux-arm64-musl/ubuntu-latest/aarch64-unknown-linux-musl`, `macos-arm64/macos-latest/aarch64-apple-darwin`, `macos-x86/macos-latest/x86_64-apple-darwin`, `windows-x64/windows-latest/x86_64-pc-windows-msvc`
+- [ ] 4.2 Add `preflight` job (`runs-on: ubuntu-latest`): `actions/checkout@v4`, `dtolnay/rust-toolchain@1.92`, `Swatinem/rust-cache@v2`, then steps: `cargo fmt --all -- --check`, `cargo clippy --locked -- -D warnings`, `cargo test --locked`
+- [ ] 4.3 Extract version from tag ref in `preflight`: `VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')` and verify it matches `Cargo.toml` via `grep -q "^version = \"$VERSION\"" Cargo.toml`
+- [ ] 4.4 Add `build-release` job (`needs: [preflight]`, `strategy.fail-fast: false`) with matrix: `linux-x64-musl/ubuntu-latest/x86_64-unknown-linux-musl`, `linux-arm64-musl/ubuntu-latest/aarch64-unknown-linux-musl`, `macos-arm64/macos-latest/aarch64-apple-darwin`, `macos-x86/macos-latest/x86_64-apple-darwin`, `windows-x64/windows-latest/x86_64-pc-windows-msvc`
 - [ ] 4.5 In `build-release`: add `cargo install cross --locked` step gated on `matrix.build_name == 'linux-arm64-musl'`; use `cross` for that leg and `cargo` for all others
 - [ ] 4.6 In `build-release`: build with `cargo build --release --locked --verbose --target ${{ matrix.target }}`
 - [ ] 4.7 In `build-release`: upload binary to GitHub release via `softprops/action-gh-release@v2` with asset name `dotagents-${{ matrix.build_name }}` (append `.exe` for windows leg)
@@ -36,13 +37,13 @@
 
 ## 6. Stage 2 — release.yml (Homebrew + Scoop)
 
-- [ ] 6.1 Add `update-homebrew` job (`needs: build-release`, `runs-on: ubuntu-latest`): download `dotagents-macos-arm64` and `dotagents-macos-x86` from the release; compute `sha256sum` for each; clone `soorya-u/homebrew-dotagents` using `RELEASE_PAT`; patch `Formula/dotagents.rb` replacing version string and both sha256 fields; commit and push to `main`
-- [ ] 6.2 Add `update-scoop` job (`needs: build-release`, `runs-on: ubuntu-latest`): download `dotagents-windows-x64.exe` from the release; compute `sha256sum`; clone `soorya-u/scoop-dotagents` using `RELEASE_PAT`; patch `bucket/dotagents.json` using `jq` to update `version` and `architecture["64bit"].hash`; commit and push to `main`
+- [ ] 6.1 Add `update-homebrew` job (`needs: [build-release, e2e]`, `runs-on: ubuntu-latest`): download `dotagents-macos-arm64` and `dotagents-macos-x86` from the release; compute `sha256sum` for each; clone `soorya-u/homebrew-dotagents` using `RELEASE_PAT`; set `git config user.name "github-actions[bot]"` and `git config user.email "41898282+github-actions[bot]@users.noreply.github.com"`; patch `Formula/dotagents.rb` replacing version string and both sha256 fields; commit and push to `main`
+- [ ] 6.2 Add `update-scoop` job (`needs: [build-release, e2e]`, `runs-on: ubuntu-latest`): download `dotagents-windows-x64.exe` from the release; compute `sha256sum`; clone `soorya-u/scoop-dotagents` using `RELEASE_PAT`; set `git config user.name "github-actions[bot]"` and `git config user.email "41898282+github-actions[bot]@users.noreply.github.com"`; patch `bucket/dotagents.json` using `jq` to update `version` and `architecture["64bit"].hash`; commit and push to `main`
 
 ## 7. Verification
 
 - [ ] 7.1 Trigger `release-prep` with version `0.1.0` via workflow_dispatch and verify the PR opens with correct title and all four files changed
-- [ ] 7.2 Merge the PR and verify Stage 2 starts, all seven jobs appear in the Actions UI, and the git tag `v0.1.0` is created
+- [ ] 7.2 Merge the PR, push annotated tag `v0.1.0`, and verify Stage 2 starts with jobs: `preflight`, `build-release` (×5), `e2e`, `publish-cargo`, `publish-npm`, `update-homebrew`, `update-scoop`
 - [ ] 7.3 Confirm the GitHub release has five binary assets and `completions.zip` attached
 - [ ] 7.4 Confirm `dotagents 0.1.0` appears on crates.io and `npm info dotagents` returns version `0.1.0`
 - [ ] 7.5 Confirm `brew tap soorya-u/dotagents && brew install dotagents` installs and runs `dotagents --version` correctly

--- a/openspec/changes/add-release-pipeline/tasks.md
+++ b/openspec/changes/add-release-pipeline/tasks.md
@@ -1,0 +1,49 @@
+## 1. Supporting files
+
+- [ ] 1.1 Create `rust-toolchain.toml` at repo root with `[toolchain]` section pinning `channel = "1.92"`
+- [ ] 1.2 Create `cliff.toml` at repo root configuring git-cliff: `[git] conventional_commits = true`, sections for `feat` (Features), `fix` (Bug Fixes), `chore` (Miscellaneous) — exclude `chore: release v*` commits from the log body
+- [ ] 1.3 Add `CHANGELOG.md` as an empty placeholder file so git-cliff can prepend to it on first run
+
+## 2. Configure GitHub secrets
+
+- [ ] 2.1 Generate a crates.io API token at crates.io → Account Settings → API Tokens and add it to repo secrets as `CRATES_IO_TOKEN`
+- [ ] 2.2 Generate an npm Automation token at npmjs.com → Access Tokens and add it to repo secrets as `NPM_TOKEN`
+- [ ] 2.3 Create a fine-grained GitHub PAT with Contents read+write on `soorya-u/homebrew-dotagents` and `soorya-u/scoop-dotagents` and add it to repo secrets as `RELEASE_PAT`
+
+## 3. Stage 1 — release-prep.yml
+
+- [ ] 3.1 Create `.github/workflows/release-prep.yml` with `on: workflow_dispatch` trigger and a single `version` input (required, description: "Version to release e.g. 0.2.0")
+- [ ] 3.2 Add step to bump version: use `sed` to replace `^version = ".*"` in `Cargo.toml` with `version = "${{ inputs.version }}"`, then run `cargo update --workspace` to sync `Cargo.lock`
+- [ ] 3.3 Add step to generate CHANGELOG: `cargo install git-cliff --locked` then `git-cliff --tag v${{ inputs.version }} --prepend CHANGELOG.md`
+- [ ] 3.4 Add step to generate shell completions: build debug binary with `cargo build --locked`, then run `./target/debug/dotagents gen-completions --shell <shell> --to completions/` for each of bash, elvish, fish, powershell, zsh, then `zip -r completions.zip completions/`
+- [ ] 3.5 Add step to open PR using `peter-evans/create-pull-request@v6` with title `"chore: release v${{ inputs.version }}"`, branch `bot/release-v${{ inputs.version }}`, committing `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, `completions.zip`
+
+## 4. Stage 2 — release.yml (tag + build)
+
+- [ ] 4.1 Create `.github/workflows/release.yml` with `on: push: branches: [main]` trigger
+- [ ] 4.2 Add early-exit check as first step of the `tag` job: `if: startsWith(github.event.head_commit.message, 'chore: release v')` condition on the entire job
+- [ ] 4.3 Add `tag` job: extract version from `Cargo.toml` via `grep -m1 '^version' Cargo.toml | cut -d'"' -f2`, create annotated tag `v$VERSION`, push tag using `GITHUB_TOKEN`
+- [ ] 4.4 Add `build-release` job (`needs: tag`, `strategy.fail-fast: false`) with matrix: `linux-x64-musl/ubuntu-latest/x86_64-unknown-linux-musl`, `linux-arm64-musl/ubuntu-latest/aarch64-unknown-linux-musl`, `macos-arm64/macos-latest/aarch64-apple-darwin`, `macos-x86/macos-latest/x86_64-apple-darwin`, `windows-x64/windows-latest/x86_64-pc-windows-msvc`
+- [ ] 4.5 In `build-release`: add `cargo install cross --locked` step gated on `matrix.build_name == 'linux-arm64-musl'`; use `cross` for that leg and `cargo` for all others
+- [ ] 4.6 In `build-release`: build with `cargo build --release --locked --verbose --target ${{ matrix.target }}`
+- [ ] 4.7 In `build-release`: upload binary to GitHub release via `softprops/action-gh-release@v2` with asset name `dotagents-${{ matrix.build_name }}` (append `.exe` for windows leg)
+
+## 5. Stage 2 — release.yml (e2e + publish)
+
+- [ ] 5.1 Add `e2e` job (`needs: build-release`, `runs-on: ubuntu-latest`): download `dotagents-linux-x64-musl` artifact from the release, `chmod +x`, place in `target/release/dotagents`, set up `oven-sh/setup-bun@v2`, run `cd tests/e2e && bunx tui-test`
+- [ ] 5.2 Add `publish-cargo` job (`needs: e2e`, `runs-on: ubuntu-latest`): `dtolnay/rust-toolchain@1.92`, `cargo publish --locked` with `CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}`
+- [ ] 5.3 Add `publish-npm` job (`needs: e2e`, `runs-on: ubuntu-latest`): write `package.json` for each platform package (`@dotagents/linux-x64` etc.) containing the binary, then write root `dotagents` shim `package.json` with `optionalDependencies` for each platform package and a `postinstall` script; publish platform packages first, then root; use `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`
+
+## 6. Stage 2 — release.yml (Homebrew + Scoop)
+
+- [ ] 6.1 Add `update-homebrew` job (`needs: build-release`, `runs-on: ubuntu-latest`): download `dotagents-macos-arm64` and `dotagents-macos-x86` from the release; compute `sha256sum` for each; clone `soorya-u/homebrew-dotagents` using `RELEASE_PAT`; patch `Formula/dotagents.rb` replacing version string and both sha256 fields; commit and push to `main`
+- [ ] 6.2 Add `update-scoop` job (`needs: build-release`, `runs-on: ubuntu-latest`): download `dotagents-windows-x64.exe` from the release; compute `sha256sum`; clone `soorya-u/scoop-dotagents` using `RELEASE_PAT`; patch `bucket/dotagents.json` using `jq` to update `version` and `architecture["64bit"].hash`; commit and push to `main`
+
+## 7. Verification
+
+- [ ] 7.1 Trigger `release-prep` with version `0.1.0` via workflow_dispatch and verify the PR opens with correct title and all four files changed
+- [ ] 7.2 Merge the PR and verify Stage 2 starts, all seven jobs appear in the Actions UI, and the git tag `v0.1.0` is created
+- [ ] 7.3 Confirm the GitHub release has five binary assets and `completions.zip` attached
+- [ ] 7.4 Confirm `dotagents 0.1.0` appears on crates.io and `npm info dotagents` returns version `0.1.0`
+- [ ] 7.5 Confirm `brew tap soorya-u/dotagents && brew install dotagents` installs and runs `dotagents --version` correctly
+- [ ] 7.6 Confirm `scoop bucket add dotagents https://github.com/soorya-u/scoop-dotagents && scoop install dotagents` installs correctly on Windows

--- a/openspec/changes/fix-e2e-release-build/.openspec.yaml
+++ b/openspec/changes/fix-e2e-release-build/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/fix-e2e-release-build/design.md
+++ b/openspec/changes/fix-e2e-release-build/design.md
@@ -1,0 +1,61 @@
+## Context
+
+The e2e test suite (`tests/e2e/`) uses `@microsoft/tui-test` to exercise the Dotagents binary. The binary path is hardcoded in `tests/e2e/helpers.ts` as `../../target/debug/dotagents`. Because the debug binary is configured (via `cfg(debug_assertions)`) to use `.dotagents-debug` as its root directory instead of `.dotagents`, every test that checks filesystem paths references `.dotagents-debug`. The `tests:e2e` mise task declares `build` (debug) as its dependency, so the debug binary is always what gets exercised.
+
+This has two concrete consequences:
+1. Tests never exercise the release binary, which is what users actually run.
+2. The 57 hardcoded `.dotagents-debug` path references would all be wrong if the binary path were switched to release without updating the path strings — and the skip on the overwrite test exists specifically because the debug binary defaults `force = true`, while the release binary requires an explicit `--force` flag.
+
+A separate concern exists in `workflow.test.ts`, which patches out the gemini target after `init`. Other tests that exercise deploy are expected to use `initWithLocalProvider()` (from `helpers.ts`), which sets up only a local provider. If any deploy test bypasses that helper and does not explicitly remove gemini, it will fail in CI environments where the gemini provider requires a local cache file.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Switch the e2e suite to run the release binary
+- Remove all `.dotagents-debug` references from test files
+- Update the `tests:e2e` mise task to build the release binary
+- Unskip the overwrite test that was blocked by debug-binary behavior
+- Audit all deploy tests for gemini provider safety in CI
+- Document `initWithLocalProvider()` as the canonical deploy-test setup
+
+**Non-Goals:**
+- Changing the debug/release root directory logic in the Rust source (`src/constants/dir.rs`)
+- Adding new test flows beyond what is needed to fix the regression
+- Modifying release build flags or LTO settings
+
+## Decisions
+
+**Decision: Switch binary path in `helpers.ts`, not via an environment variable.**
+An env var would add indirection and require every CI step to set it. The binary path is a test infrastructure constant; a direct string change in one place is simpler and self-documenting.
+
+*Alternative considered*: Parameterize via `process.env.DOTAGENTS_BIN`. Rejected because it adds configuration surface with no benefit — the release binary is always what the suite should test.
+
+**Decision: Global string replace for `.dotagents-debug` → `.dotagents`.**
+All 57 occurrences are mechanical: they appear in `existsSync`, `readFileSync`, and `getByText` assertions. A targeted per-file approach gives no benefit over a global replace and is harder to audit.
+
+**Decision: Change `tests:e2e` dependency from `build` to `build-release` in `mise.toml`.**
+The suite must always compile the release binary before running. This makes the dependency explicit and prevents the suite from running a stale debug build.
+
+**Decision: Audit for gemini safety is code-review, not a new abstraction.**
+Rather than introducing a new `safeInit()` wrapper, the fix is to verify that all deploy tests already call `initWithLocalProvider()` (or explicitly patch gemini out). Adding a comment to `initWithLocalProvider()` makes the intent clear for future test authors.
+
+## Risks / Trade-offs
+
+- [Longer CI time] Release builds are slower than debug builds (LTO, optimizations). → Acceptable: correctness beats speed; `mise tests:unit` and `mise tests:integration` still use the debug build.
+- [Rebase conflict with `fix-init-dir-timing`] Both changes touch `init.test.ts`. → The conflict is mechanical (line-level); whoever merges second rebases and picks both changes.
+
+## Migration Plan
+
+1. Update `mise.toml` `tests:e2e` dependency.
+2. Update binary path in `helpers.ts`.
+3. Global-replace `.dotagents-debug` → `.dotagents` across all `tests/e2e/*.test.ts` files.
+4. Unskip the overwrite test in `init.test.ts`.
+5. Audit deploy tests; patch any that lack gemini safety.
+6. Add explanatory comment to `initWithLocalProvider()` in `helpers.ts`.
+7. Run `mise check && mise tests` — both must exit 0.
+
+Rollback: revert the `helpers.ts` binary path and `mise.toml` dependency; the string replacements are forward-only (no `.dotagents-debug` should remain after the fix).
+
+## Open Questions
+
+None. The change is fully scoped and the affected files are identified.

--- a/openspec/changes/fix-e2e-release-build/proposal.md
+++ b/openspec/changes/fix-e2e-release-build/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The e2e test suite runs the debug binary, which uses `.dotagents-debug` as its root directory instead of `.dotagents`. This means tests currently verify debug-build behavior rather than the release binary shipped to users, and any test that hardcodes `.dotagents-debug` will fail as soon as the suite is pointed at the release binary. Additionally, certain deploy tests do not use `initWithLocalProvider()` and may include the gemini provider, which requires a local cache file unavailable in CI.
+
+## What Changes
+
+- `tests/e2e/helpers.ts`: binary path changed from `../../target/debug/dotagents` to `../../target/release/dotagents`
+- `tests/e2e/*.test.ts`: all 57 occurrences of `.dotagents-debug` replaced with `.dotagents`
+- `mise.toml`: `tests:e2e` task dependency changed from `build` to `build-release`
+- `tests/e2e/init.test.ts`: overwrite test unskipped (skip reason was debug binary's force-default; release binary requires explicit `--force`)
+- `tests/e2e/helpers.ts`: explanatory comment added to `initWithLocalProvider()` marking it as the canonical deploy-test helper
+- All deploy tests audited; any that don't use `initWithLocalProvider()` and don't explicitly remove gemini from the active targets are fixed
+
+## Capabilities
+
+### New Capabilities
+
+- `e2e-test-build`: Requirements covering which binary the e2e suite must run, which root directory name tests must reference, and which provider setup is required for CI-safe deploy tests
+
+### Modified Capabilities
+
+<!-- No existing spec requirements change behavior — the tui-test-e2e-suite spec does not prescribe the binary target or root dir name, so no delta spec is needed for it. -->
+
+## Impact
+
+- `tests/e2e/helpers.ts` — binary path and `initWithLocalProvider()` comment
+- `tests/e2e/*.test.ts` — global string replacement of `.dotagents-debug` → `.dotagents` (57 occurrences)
+- `tests/e2e/init.test.ts` — unskip one test case
+- `mise.toml` — task dependency update (`build` → `build-release`)
+- CI pipelines that run `mise tests` are not affected in interface, only in which binary gets built before the suite

--- a/openspec/changes/fix-e2e-release-build/specs/e2e-test-build/spec.md
+++ b/openspec/changes/fix-e2e-release-build/specs/e2e-test-build/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: E2E suite runs the release binary
+The e2e test suite SHALL invoke the release binary (`target/release/dotagents`). The `tests:e2e` mise task SHALL declare `build-release` as its dependency so the release binary is always compiled before the suite runs.
+
+#### Scenario: Binary path resolves to release build
+- **WHEN** a tui-test test spawns the Dotagents binary via the path defined in `tests/e2e/helpers.ts`
+- **THEN** the process that runs is `target/release/dotagents`, not `target/debug/dotagents`
+
+#### Scenario: Mise task builds release binary before running suite
+- **WHEN** `mise tests:e2e` is invoked
+- **THEN** `mise build-release` completes before any test process is spawned
+
+### Requirement: No `.dotagents-debug` references in e2e test files
+All e2e test files under `tests/e2e/` SHALL reference `.dotagents` as the root directory name. The string `.dotagents-debug` SHALL NOT appear in any file under `tests/e2e/`.
+
+#### Scenario: Filesystem assertions use correct root directory name
+- **WHEN** an e2e test checks for the existence of a file inside the Dotagents root directory
+- **THEN** the path used in the assertion contains `.dotagents`, not `.dotagents-debug`
+
+#### Scenario: Terminal output assertions use correct root directory name
+- **WHEN** an e2e test uses `getByText` to assert on output that includes the root directory path
+- **THEN** the expected string contains `.dotagents`, not `.dotagents-debug`
+
+### Requirement: Overwrite test exercises release-binary behavior
+The overwrite test in `tests/e2e/init.test.ts` SHALL be active (not skipped). It SHALL verify that the release binary requires an explicit `--force` flag to overwrite an existing root directory.
+
+#### Scenario: Init without --force fails on existing root
+- **WHEN** `dotagents init` runs in a workspace that already contains a `.dotagents/` directory and `--force` is not passed
+- **THEN** the process exits non-zero and the existing directory is not modified
+
+#### Scenario: Init with --force succeeds on existing root
+- **WHEN** `dotagents init --force` runs in a workspace that already contains a `.dotagents/` directory
+- **THEN** the process exits zero and the root directory is re-scaffolded
+
+### Requirement: Deploy tests are CI-safe with respect to the gemini provider
+Every deploy test in `tests/e2e/` SHALL either use `initWithLocalProvider()` from `helpers.ts` or explicitly remove the gemini provider from the active targets before running deploy. No deploy test SHALL rely on a gemini local cache file.
+
+#### Scenario: Deploy test using initWithLocalProvider never activates gemini
+- **WHEN** a deploy test calls `initWithLocalProvider()` to set up the workspace
+- **THEN** only the local test provider is active and gemini is not present in the deploy target list
+
+#### Scenario: Deploy test that does not use initWithLocalProvider patches out gemini
+- **WHEN** a deploy test sets up its workspace without `initWithLocalProvider()`
+- **THEN** it explicitly removes or disables the gemini provider from `config.toml` or `local.config.toml` before invoking deploy
+
+### Requirement: initWithLocalProvider is documented as canonical deploy-test setup
+The `initWithLocalProvider()` function in `tests/e2e/helpers.ts` SHALL have a comment explaining that it is the canonical helper for deploy tests because it sets up only a local provider and avoids CI-unsafe external providers such as gemini.
+
+#### Scenario: Comment is present on initWithLocalProvider
+- **WHEN** a developer reads `tests/e2e/helpers.ts`
+- **THEN** `initWithLocalProvider()` has a comment stating it is the required setup for deploy tests and explaining why (no gemini dependency)

--- a/openspec/changes/fix-e2e-release-build/tasks.md
+++ b/openspec/changes/fix-e2e-release-build/tasks.md
@@ -1,0 +1,28 @@
+## 1. Build Infrastructure
+
+- [ ] 1.1 In `mise.toml`, change the `tests:e2e` task's `depends` entry from `build` to `build-release`
+- [ ] 1.2 In `tests/e2e/helpers.ts` line 8, change the binary path from `../../target/debug/dotagents` to `../../target/release/dotagents`
+
+## 2. Root Directory References
+
+- [ ] 2.1 In all files matching `tests/e2e/*.test.ts`, globally replace every occurrence of `.dotagents-debug` with `.dotagents` (57 occurrences total)
+- [ ] 2.2 Verify no `.dotagents-debug` string remains anywhere under `tests/e2e/` after the replace
+
+## 3. Overwrite Test
+
+- [ ] 3.1 In `tests/e2e/init.test.ts`, remove the `test.skip` (or equivalent skip annotation) from the overwrite test whose skip reason references the debug binary defaulting `force = true`
+- [ ] 3.2 Confirm the unskipped test asserts that `dotagents init` fails without `--force` on an existing root and succeeds with `--force`
+
+## 4. Gemini Safety Audit
+
+- [ ] 4.1 Read every deploy test in `tests/e2e/` that does NOT call `initWithLocalProvider()`; list any that do not also explicitly patch out or disable the gemini provider
+- [ ] 4.2 For each unsafe deploy test identified in 4.1, add the gemini-removal step (mirror the pattern in `workflow.test.ts` line 178) before the deploy invocation
+
+## 5. Documentation
+
+- [ ] 5.1 In `tests/e2e/helpers.ts`, add a comment directly above `initWithLocalProvider()` stating it is the canonical setup for deploy tests because it activates only a local provider and avoids CI-unsafe providers such as gemini
+
+## 6. Verification
+
+- [ ] 6.1 Run `mise check` and confirm exit code 0 (cargo fmt + clippy)
+- [ ] 6.2 Run `mise tests` and confirm exit code 0 (unit + integration + e2e)

--- a/openspec/changes/fix-e2e-release-build/tasks.md
+++ b/openspec/changes/fix-e2e-release-build/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Build Infrastructure
 
-- [ ] 1.1 In `mise.toml`, change the `tests:e2e` task's `depends` entry from `build` to `build-release`
+- [ ] 1.1 In `mise.toml`, change the `tests:e2e` task's `depends` entry from `build` to `build:release`
 - [ ] 1.2 In `tests/e2e/helpers.ts` line 8, change the binary path from `../../target/debug/dotagents` to `../../target/release/dotagents`
 
 ## 2. Root Directory References

--- a/openspec/changes/fix-error-handling/.openspec.yaml
+++ b/openspec/changes/fix-error-handling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/fix-error-handling/design.md
+++ b/openspec/changes/fix-error-handling/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The CLI exposes a `display_error()` function that renders errors as a formatted box with a cause chain. All subcommands are expected to return `anyhow::Result<bool>` so that `main.rs` can route failures through this path. However, `Templater` is initialized in a `LazyLock<Templater>` static, which requires an infallible closure. The original author worked around this by calling `.expect()` inside the closure. When `load_default_variables()` fails (most commonly: no workspace directory found), the expect fires and the process aborts with a raw Rust panic message rather than flowing through `display_error()`. The `undeploy` subcommand does not use `get_templater()` directly and therefore already surfaces the same workspace-not-found error correctly.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `Templater::new()` fully fallible — remove the `.expect()` inside it.
+- Change `get_templater()` to return `Result<&'static Templater>` so callers can propagate initialization failures with `?`.
+- Ensure that a missing workspace directory (and any other `Templater` initialization failure) reaches `display_error()` and exits with code 1, matching `undeploy` behavior.
+- Add an e2e test confirming the formatted error output on deploy failure.
+
+**Non-Goals:**
+- Replacing `anyhow` with `thiserror`. The codebase is a CLI app, not a library. `anyhow` is correct here; the bug is a single misplaced `.expect()`, not an architectural error-type problem.
+- Changing `undeploy` error handling (it already works correctly).
+- Caching the error result across calls (if initialization fails, the process will exit at the first call site anyway).
+
+## Decisions
+
+### Keep `anyhow` as the error type
+
+`thiserror` is appropriate for libraries that need to expose typed error variants to downstream consumers. `dotagents` is a CLI binary; callers (i.e. the OS) only receive an exit code. `anyhow` with `.context()` chains already produces informative error messages through `display_error()`. Switching to `thiserror` would add ceremony without benefit.
+
+### Use `OnceLock<Templater>` instead of `LazyLock<Templater>`
+
+`LazyLock` requires an infallible initializer (`FnOnce() -> T`). There is no way to surface a `Result` from inside it without `.unwrap()` / `.expect()`. `OnceLock<Templater>` supports a fallible initialization pattern: `get_or_try_init(|| Templater::new())` returns `Result<&Templater>`. This is the idiomatic Rust solution for fallible statics. The alternative — `LazyLock<Result<Templater>>` — would require unwrapping the inner `Result` at every call site and would leave the error value alive in the static forever; `OnceLock` avoids both problems.
+
+### Propagate with `?`, not `.unwrap()`
+
+All `get_templater()` call sites already operate inside `Result`-returning functions. Adding `?` after `get_templater()?` is sufficient; no intermediate error wrapping is needed beyond the `.context()` already inside `Templater::new()`.
+
+## Risks / Trade-offs
+
+- [Risk] `OnceLock::get_or_try_init` is stabilized in Rust 1.70+ — the project's MSRV must be at or above this. → Mitigation: verify `rust-toolchain.toml` or `Cargo.toml` edition before merging; the project already uses `LazyLock` (stable since 1.80) so MSRV is sufficient.
+- [Risk] The comment on line 166 of `deploy.rs` ("Must be called before get_templater()") documents order-of-initialization sensitivity. Changing to `OnceLock` preserves this because `get_or_try_init` only fires on first call, and `set_env_paths` is still called before `get_templater()`. → Mitigation: keep the comment accurate; ensure no new call site calls `get_templater()` before `set_env_paths`.
+
+## Migration Plan
+
+1. Change `Templater::new()` to propagate `load_default_variables()` errors with `?` instead of `.expect()`.
+2. Replace `static TEMPLATER: LazyLock<Templater>` with `static TEMPLATER: OnceLock<Templater>`.
+3. Rewrite `get_templater()` to call `TEMPLATER.get_or_try_init(Templater::new)` and return `Result<&'static Templater>`.
+4. Grep for all `get_templater()` call sites in `src/` and append `?` (or `.context(...)` if additional context improves the error message).
+5. Run `mise check` and `mise tests` to confirm no regressions.
+6. Add e2e test in `tests/e2e/` asserting exit code 1 and formatted error box (no "panicked at") when deploy runs with no workspace directory.
+
+No rollback strategy needed — this is a pure error-path improvement with no protocol or file-format changes.
+
+## Open Questions
+
+- None. The approach is fully determined by the existing codebase patterns.

--- a/openspec/changes/fix-error-handling/proposal.md
+++ b/openspec/changes/fix-error-handling/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`deploy` panics with a raw Rust backtrace when initialization fails (e.g. no workspace directory), while `undeploy` surfaces the same failure as a formatted error box via `display_error()`. This inconsistency exposes internal implementation details to users and bypasses the CLI's established error-presentation contract.
+
+## What Changes
+
+- `Templater::new()` is changed to return `Result<Templater>` instead of panicking on initialization failure.
+- `get_templater()` is changed from returning `&'static Templater` to returning `Result<&'static Templater>`, backed by `OnceLock<Templater>` instead of `LazyLock<Templater>`.
+- The `.expect("failed to load global variables")` call inside the `LazyLock` initializer is removed; errors now propagate via `?`.
+- All call sites of `get_templater()` are updated to handle the `Result` (add `?` or `.context(...)`).
+- An e2e test is added asserting that running `deploy` with no workspace directory exits with code 1 and shows a formatted error box on stderr (not raw panic text).
+
+## Capabilities
+
+### New Capabilities
+
+- `error-display-consistency`: Deploy and undeploy must both surface initialization and runtime errors through `display_error()`, producing a consistent formatted error box rather than a raw panic.
+
+### Modified Capabilities
+
+<!-- No existing spec-level behavior is changing — this is a bug fix bringing deploy into conformance with the CLI's existing error-presentation behavior. -->
+
+## Impact
+
+- `src/templates/templater.rs` — primary change site; `LazyLock` replaced with `OnceLock`, `Templater::new` made fallible.
+- All callers of `get_templater()` in `src/` — must be found with grep and updated to propagate the `Result`.
+- `tests/e2e/` — new test for formatted error output on deploy failure.
+- No new dependencies. No public API changes. No breaking changes for end users (error output improves).

--- a/openspec/changes/fix-error-handling/specs/error-display-consistency/spec.md
+++ b/openspec/changes/fix-error-handling/specs/error-display-consistency/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Deploy surfaces errors through display_error
+When the `deploy` subcommand fails during initialization (e.g., no workspace directory, failed variable loading), it SHALL exit with code 1 and print a formatted error box to stderr via `display_error()`. It MUST NOT produce a raw Rust panic message.
+
+#### Scenario: Deploy with no workspace directory prints formatted error
+- **WHEN** the user runs `dotagents deploy` from a directory that has no `.dotagents` ancestor
+- **THEN** the process exits with code 1
+- **THEN** stderr contains a formatted error box (e.g., text matching `■` or `Fatal error`)
+- **THEN** stderr does NOT contain the text "panicked at"
+
+#### Scenario: Deploy error output matches undeploy error output format
+- **WHEN** both `deploy` and `undeploy` fail due to a missing workspace directory
+- **THEN** both commands exit with code 1
+- **THEN** both commands produce error output using the same `display_error()` formatted box structure
+- **THEN** neither command emits raw Rust panic text
+
+### Requirement: get_templater returns Result
+The `get_templater()` function SHALL return `Result<&'static Templater>` so that callers can propagate initialization failures with the `?` operator into their own `Result`-returning functions, allowing errors to reach `main.rs` and flow through `display_error()`.
+
+#### Scenario: Templater initialization failure propagates to caller
+- **WHEN** `Templater::new()` returns an `Err` (e.g., workspace directory cannot be resolved)
+- **THEN** `get_templater()` returns that same `Err`
+- **THEN** the calling function propagates it with `?`
+- **THEN** `main.rs` receives the error and calls `display_error()` before exiting with code 1
+
+#### Scenario: Templater initialization success behaves as before
+- **WHEN** `Templater::new()` succeeds (workspace directory exists, variables load correctly)
+- **THEN** `get_templater()` returns `Ok(&'static Templater)`
+- **THEN** callers receive the same usable `Templater` reference as before

--- a/openspec/changes/fix-error-handling/tasks.md
+++ b/openspec/changes/fix-error-handling/tasks.md
@@ -1,0 +1,25 @@
+## 1. Discover Call Sites
+
+- [ ] 1.1 Run `grep -rn "get_templater()" src/` to list every call site that will need updating after the signature change
+
+## 2. Make Templater Initialization Fallible
+
+- [ ] 2.1 In `src/templates/templater.rs`, change `Templater::new()` to propagate `load_default_variables()` with `?` instead of `.expect("failed to load global variables")`
+- [ ] 2.2 Replace `static TEMPLATER: LazyLock<Templater>` with `static TEMPLATER: OnceLock<Templater>` and update the import (`use std::sync::OnceLock`)
+- [ ] 2.3 Rewrite `get_templater()` to use `TEMPLATER.get_or_try_init(Templater::new)` and return `Result<&'static Templater>`
+
+## 3. Update Call Sites
+
+- [ ] 3.1 In `src/cli/deploy.rs`, add `?` after `get_templater()` (or `.context("failed to initialise templater")`) so the error propagates to `main.rs`
+- [ ] 3.2 In `src/cli/skills.rs`, add `?` after `get_templater()` so the error propagates to `main.rs`
+- [ ] 3.3 Check every other call site found in task 1.1 and apply the same `?` / `.context()` treatment
+
+## 4. Verify and Lint
+
+- [ ] 4.1 Run `mise check` (`cargo fmt` + `cargo clippy`) and fix any warnings or formatting issues
+- [ ] 4.2 Run `mise tests` (unit + integration + e2e) and confirm all suites pass
+
+## 5. Add E2E Test
+
+- [ ] 5.1 In `tests/e2e/` (in `errors.test.ts` or `deploy.test.ts`), add a test that runs `deploy` from a temp directory with no `.dotagents` ancestor, asserts exit code 1, asserts stderr contains the formatted error box text (e.g., `Fatal error` or `■`), and asserts stderr does NOT contain `panicked at`
+- [ ] 5.2 Run `mise tests:e2e` to confirm the new test passes

--- a/openspec/changes/fix-init-dir-timing/.openspec.yaml
+++ b/openspec/changes/fix-init-dir-timing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/fix-init-dir-timing/design.md
+++ b/openspec/changes/fix-init-dir-timing/design.md
@@ -1,0 +1,36 @@
+## Context
+
+`dotagents init` in `src/cli/init.rs` calls `fs::create_dir_all(&workspace)` on line 113 before the TUI wizard runs. This was added to guarantee the workspace parent exists before `try_exists()` is called on line 115 to check whether `.dotagents/` already exists inside it. However, `try_exists()` returns `Ok(false)` when the parent path does not exist, making the pre-creation unnecessary. The side-effect is that cancelling the wizard still creates the workspace directory on disk.
+
+The actual `.dotagents/` directory is created at line 142, after all TUI prompts complete — that part is correctly deferred. Only the parent workspace creation happens too early.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ensure no filesystem writes occur if the user cancels the init wizard.
+- Keep `try_exists()` correct: it does not need a pre-created parent to return `Ok(false)`.
+- Add an e2e test that proves cancellation leaves no directory on disk.
+
+**Non-Goals:**
+
+- Changing any wizard prompt behavior, text, or ordering.
+- Changing behavior of headless (flag-driven) init.
+- Altering how the `.dotagents/` directory itself is created after the wizard.
+
+## Decisions
+
+### Move `create_dir_all` to after the TUI block
+
+`try_exists()` on a path whose parent does not exist returns `Ok(false)`, not an error. The pre-creation was therefore a defensive no-op that introduced a side-effect. Moving `fs::create_dir_all(&workspace)` to just before `fs::create_dir(&main_dir)` on line 142 is the minimal correct fix.
+
+Alternative considered: wrapping `create_dir_all` in a conditional to skip it when in TUI mode. Rejected because it adds complexity for no benefit — deferring is simpler and correct for both modes.
+
+### No change to headless (flag) path behavior
+
+When flags are present, `tui_mode` is false and the wizard block is skipped entirely, so the workspace creation timing change is a no-op for flag-driven invocations. The behavior is identical to before.
+
+## Risks / Trade-offs
+
+- [Risk] `try_exists()` behavior across filesystems when parent is absent — Mitigation: this is guaranteed by the Rust standard library; `try_exists` returns `Ok(false)` rather than `Err` for non-existent paths, which the existing test suite exercises.
+- [Risk] e2e test for cancellation requires tui-devtools discovery to capture exact prompt output — Mitigation: the tasks.md calls out the tui-devtools pass as a required step before writing the e2e assertion.

--- a/openspec/changes/fix-init-dir-timing/proposal.md
+++ b/openspec/changes/fix-init-dir-timing/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`dotagents init` creates the workspace directory on disk before the TUI wizard runs, so cancelling the wizard leaves a spurious directory behind. Directory creation should be deferred until the user completes the wizard and confirms they want to proceed.
+
+## What Changes
+
+- Move `fs::create_dir_all(&workspace)` in `src/cli/init.rs` from before the `try_exists()` check to after the TUI wizard block, so no filesystem writes occur if the user cancels.
+- Add an e2e test that asserts cancelling the init wizard leaves no directory on disk.
+
+## Capabilities
+
+### New Capabilities
+
+- `init-dir-timing`: Behavioral invariant that `dotagents init` produces no filesystem side-effects when the user cancels the TUI wizard.
+
+### Modified Capabilities
+
+- `init-wizard`: The requirement that no filesystem writes occur on wizard cancellation is a spec-level behavioral change for the existing init wizard capability.
+
+## Impact
+
+- `src/cli/init.rs` — one-line move of `fs::create_dir_all` call
+- `tests/e2e/init.test.ts` — new test case covering cancellation with no leftover directory
+- No API changes, no new dependencies, no breaking changes

--- a/openspec/changes/fix-init-dir-timing/specs/init-dir-timing/spec.md
+++ b/openspec/changes/fix-init-dir-timing/specs/init-dir-timing/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Cancelling the init wizard leaves no filesystem trace
+When the user cancels the `dotagents init` TUI wizard (e.g. by selecting No at any prompt or pressing Ctrl-C), the CLI SHALL exit 0 without creating any directory or file on disk — including the workspace directory itself.
+
+#### Scenario: User cancels at first prompt — no directory created
+- **WHEN** `dotagents init` is run in a fresh directory with no pre-existing workspace, and the user cancels the wizard before completing it
+- **THEN** the process exits 0 and no new directory has been created in the working directory
+
+#### Scenario: User accepts wizard — workspace directory is created
+- **WHEN** `dotagents init` is run and the user completes the wizard without cancelling
+- **THEN** the `.dotagents/` directory is created and all scaffold files are written
+
+### Requirement: Workspace directory is not created before TUI prompts run
+`fs::create_dir_all` for the workspace root SHALL NOT be called before the TUI wizard block executes. The call SHALL occur after all prompts complete and the user has confirmed they want to proceed.
+
+#### Scenario: Workspace parent already exists
+- **WHEN** the workspace root directory already exists and the user completes the wizard
+- **THEN** `dotagents init` succeeds and `.dotagents/` is created inside it (unchanged behavior)
+
+#### Scenario: Workspace parent does not exist and user cancels
+- **WHEN** the workspace root directory does not yet exist and the user cancels the wizard
+- **THEN** neither the workspace root nor any subdirectory is created
+
+#### Scenario: try_exists check works without pre-created parent
+- **WHEN** `dotagents init` is run in a directory where the workspace path does not yet exist
+- **THEN** the existing-directory detection (checking for `.dotagents/` inside the workspace) correctly reports false without requiring the parent to be created first

--- a/openspec/changes/fix-init-dir-timing/specs/init-wizard/spec.md
+++ b/openspec/changes/fix-init-dir-timing/specs/init-wizard/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Init wizard runs when no flags are given in a TTY
+When `dotagents init` is invoked with no `--features` flag and no `--template` flag, and stdin is an interactive terminal, the CLI SHALL display an interactive cliclack prompt sequence before writing any files. No filesystem writes of any kind SHALL occur before the wizard completes and the user confirms intent to proceed.
+
+#### Scenario: Full wizard flow with no flags in TTY
+- **WHEN** `dotagents init` is run with no flags in an interactive terminal
+- **THEN** the wizard shows: intro header, feature multiselect, template select, and per-file log steps, then an outro message
+
+#### Scenario: --features flag presence skips wizard
+- **WHEN** `dotagents init --features commands` is run (any `--features` value or `--template` flag present)
+- **THEN** no interactive prompts are shown and init proceeds immediately using the provided feature list
+
+#### Scenario: Non-TTY skips wizard silently
+- **WHEN** `dotagents init` is run with stdin not attached to a terminal (e.g. piped or CI)
+- **THEN** no prompts are shown; init proceeds with all features enabled and Starter template
+
+#### Scenario: Wizard cancelled — no directory created
+- **WHEN** `dotagents init` is run in an interactive terminal and the user cancels the wizard
+- **THEN** init exits 0 and no directory or file has been written to disk

--- a/openspec/changes/fix-init-dir-timing/tasks.md
+++ b/openspec/changes/fix-init-dir-timing/tasks.md
@@ -1,0 +1,27 @@
+## 1. Source Fix
+
+- [ ] 1.1 In `src/cli/init.rs`, remove `fs::create_dir_all(&workspace)` from line 113 (before the `try_exists()` call)
+- [ ] 1.2 In `src/cli/init.rs`, add `fs::create_dir_all(&workspace)` after the TUI wizard block (after line 126, before the `if dir_exists` check at line 128)
+- [ ] 1.3 Run `mise check` and confirm it exits 0 (no fmt or clippy errors)
+
+## 2. Unit / Integration Verification
+
+- [ ] 2.1 Run `mise run tests:unit` and confirm existing unit tests still pass
+- [ ] 2.2 Run `mise run tests:integration` and confirm integration tests (flag-driven paths) still pass
+
+## 3. TUI Discovery
+
+- [ ] 3.1 Start `tui-devtools` as a daemon from a mise shell
+- [ ] 3.2 Drive the init wizard cancellation flow through a real PTY in a fresh temp directory and record exact terminal output (prompt text, symbols, spacing)
+- [ ] 3.3 Confirm that after cancellation the temp directory contains no new subdirectories
+
+## 4. E2E Tests
+
+- [ ] 4.1 In `tests/e2e/init.test.ts`, add a test that runs `dotagents init` in a fresh temp workspace, cancels the wizard (presses Ctrl-C or selects No), and asserts the process exits 0 with no directory created
+- [ ] 4.2 In `tests/e2e/init.test.ts`, add (or confirm) a test that runs `dotagents init` in a fresh temp workspace, completes the wizard, and asserts `.dotagents/` is created with all expected scaffold files
+- [ ] 4.3 Run `mise run tests:e2e` and confirm all e2e tests pass
+
+## 5. Final Verification
+
+- [ ] 5.1 Run `mise check` — must exit 0
+- [ ] 5.2 Run `mise tests` — must exit 0

--- a/openspec/changes/fix-mock-files/.openspec.yaml
+++ b/openspec/changes/fix-mock-files/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/fix-mock-files/design.md
+++ b/openspec/changes/fix-mock-files/design.md
@@ -1,0 +1,33 @@
+## Context
+
+Mock file contents are defined as `&'static str` constants in `src/constants/mocks.rs` and written verbatim to disk during `dotagents init`. The MCP JSON Schema lives at `public/v1/schemas/mcp.schema.json` and is served publicly for editor tooling. All three bugs are independent single-point edits with no runtime behaviour change — the mocks are write-only during init, and the schema is never read by the Rust binary itself.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate all JSON Schema validator warnings on freshly-initialised workspace files.
+- Keep the generated `mcp.jsonc` valid against `public/v1/schemas/mcp.schema.json`.
+
+**Non-Goals:**
+- Changing any runtime parsing or deploy behaviour.
+- Restructuring how mocks are stored or loaded.
+- Modifying any provider template.
+
+## Decisions
+
+**`$schema` in the JSON Schema root — add as explicit property, not remove from mock**
+
+Options considered:
+1. Remove `"$schema"` from `MCP_MOCK` so validators never see it.
+2. Add `"$schema"` to the root `properties` so validators allow it.
+
+Option 2 is correct: `$schema` is standard JSON Schema practice for associating a file with its schema, and editors rely on it for autocompletion and validation. Removing it would break that tooling integration, which is the whole point of the key.
+
+**`env_file` → `envFile` with a real example value**
+
+The schema uses camelCase throughout (per the MCP specification and the CLAUDE.md convention). The value changes from `null` (invalid for `type: string`) to `".env.local"` — a concrete example that is also useful as documentation for the user.
+
+## Risks / Trade-offs
+
+- [Tests asserting on raw `.gitignore` or `mcp.jsonc` content will break] → Update those assertions as part of this change; the breakage is intentional and caught by `mise tests`.
+- [No risk of runtime regression] → The mocks are never parsed by the Rust binary during normal operation; only `init` reads and writes them.

--- a/openspec/changes/fix-mock-files/proposal.md
+++ b/openspec/changes/fix-mock-files/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Three small correctness bugs in the mock files scaffolded by `dotagents init` cause immediate validator noise in editors that support JSON Schema — users see errors the moment they open the generated files, undermining confidence in the tool.
+
+## What Changes
+
+- Remove `cache/` from the `.gitignore` mock in `src/constants/mocks.rs` — no such directory is created by the tool, so including it is misleading dead noise.
+- Add `"$schema"` as an allowed property in `public/v1/schemas/mcp.schema.json` — the root object has `additionalProperties: false` with only `servers` in `properties`, so the `$schema` key that `mcp.jsonc` emits for editor tooling is currently rejected.
+- Fix `"env_file": null` → `"envFile": ".env.local"` in the `MCP_MOCK` constant — the schema defines the property as `envFile` (camelCase), and `null` is not a valid `string` value; this causes two separate validation errors on the generated file.
+
+## Capabilities
+
+### New Capabilities
+
+*(none — pure correctness fix, no new capabilities introduced)*
+
+### Modified Capabilities
+
+*(none — no existing specs affected)*
+
+## Impact
+
+- `src/constants/mocks.rs` — two constant edits (`GITIGNORE` and `MCP_MOCK`)
+- `public/v1/schemas/mcp.schema.json` — add `"$schema"` property to root `properties` object
+- Any test that asserts on generated `.gitignore` or `mcp.jsonc` content must be updated to match the corrected values

--- a/openspec/changes/fix-mock-files/specs/mock-file-correctness/spec.md
+++ b/openspec/changes/fix-mock-files/specs/mock-file-correctness/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Generated .gitignore must not include non-existent paths
+The `.gitignore` written by `dotagents init` SHALL only list paths that the tool actually creates. The entry `cache/` SHALL NOT appear in the generated file because no such directory is ever created by the tool.
+
+#### Scenario: Fresh init produces correct gitignore
+- **WHEN** user runs `dotagents init` in an empty directory
+- **THEN** the generated `.dotagents/.gitignore` does not contain the line `cache/`
+- **THEN** the generated `.dotagents/.gitignore` does contain `cache.toml`, `local.config.toml`, and `.env`
+
+### Requirement: Generated mcp.jsonc must be valid against the published MCP schema
+The `mcp.jsonc` written by `dotagents init` SHALL pass validation against `public/v1/schemas/mcp.schema.json` with zero errors.
+
+#### Scenario: $schema key is accepted by the schema validator
+- **WHEN** the MCP schema file is loaded by an editor or JSON Schema validator
+- **THEN** the `$schema` property at the root of `mcp.jsonc` is recognised as valid (not flagged as an unknown property)
+
+#### Scenario: envFile key uses correct camelCase spelling
+- **WHEN** the generated `mcp.jsonc` is validated against the MCP schema
+- **THEN** the `envFile` property (camelCase) is accepted on a `stdio`-type server entry
+- **THEN** no "Property env_file is not allowed" error is reported
+
+#### Scenario: envFile value is a valid string
+- **WHEN** the generated `mcp.jsonc` contains an `envFile` entry
+- **THEN** its value is a non-null string (e.g. `".env.local"`)
+- **THEN** no type mismatch error is reported for that field

--- a/openspec/changes/fix-mock-files/tasks.md
+++ b/openspec/changes/fix-mock-files/tasks.md
@@ -1,0 +1,20 @@
+## 1. Fix .gitignore mock
+
+- [ ] 1.1 In `src/constants/mocks.rs`, remove `cache/\n` from the `GITIGNORE` constant (line 79). Result: `"cache.toml\nlocal.config.toml\n.env\n"`.
+- [ ] 1.2 Search for any test asserting on `.gitignore` content (e.g. in `tests/e2e/init.test.ts` or integration tests) and update the expected string to omit `cache/`.
+
+## 2. Fix MCP JSON Schema — allow $schema at root
+
+- [ ] 2.1 In `public/v1/schemas/mcp.schema.json`, add a `"$schema"` entry under the top-level `"properties"` object with `"type": "string"`, `"description": "JSON Schema URI for editor tooling."`, and `"format": "uri"`.
+- [ ] 2.2 Confirm the updated schema file is itself valid JSON (no trailing commas, correct nesting).
+
+## 3. Fix MCP mock — env_file → envFile
+
+- [ ] 3.1 In `src/constants/mocks.rs`, in the `MCP_MOCK` constant, change `"env_file": null` to `"envFile": ".env.local"` inside the `server-stdio` example.
+- [ ] 3.2 Confirm the updated mock parses correctly through `McpFeature::from_string` — run `cargo test` and check that existing mock-parse unit tests pass.
+
+## 4. Verification
+
+- [ ] 4.1 Run `mise check` — no fmt/clippy errors.
+- [ ] 4.2 Run `mise tests` — all tests pass.
+- [ ] 4.3 Run `cargo run -- init` in a temp dir; open the generated `mcp.jsonc` and `.gitignore` in an editor with JSON Schema support and confirm zero validation warnings.


### PR DESCRIPTION
- add-pr-ci: PR gating (fmt, clippy, tests, cross-platform checks)
- add-release-pipeline: Two-stage release to crates.io, npm, Homebrew, Scoop
- fix-e2e-release-build: E2E suite to test release binary, not debug
- fix-error-handling: Error display consistency improvements
- fix-init-dir-timing: Init directory timing and UX improvements
- fix-mock-files: Mock file correctness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PR CI that enforces formatting, linting, and test standards before merge.
  * Added multi-stage release pipeline for automated builds and publishing.

* **Bug Fixes**
  * Improved error handling to display formatted error messages instead of raw panic traces.
  * Fixed init command to prevent creating directories when user cancels.
  * Corrected mock workspace files to validate without schema warnings.
  * E2E tests now validate release binaries instead of debug binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->