### PR TITLE
Support pre-release tags in CI release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,12 +96,14 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dotagents-${{ matrix.build_name }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
       - name: Upload binary to release (windows)
         if: matrix.os == 'windows-latest'
         uses: softprops/action-gh-release@v2
         with:
           files: dotagents-${{ matrix.build_name }}.exe
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
   e2e:
     needs: [build-release]

--- a/scripts/ci/publish_npm.sh
+++ b/scripts/ci/publish_npm.sh
@@ -4,9 +4,21 @@ set -euo pipefail
 # Publishes platform-specific npm packages and the root dotagents shim package.
 # Required env: TAG, GH_TOKEN
 # Uses OIDC trusted publishing (--provenance) — no NPM_TOKEN needed.
+# Pre-release tags (e.g. v0.0.0-nightly) are published under a dist-tag
+# instead of "latest" so stable users are unaffected.
 
 TAG="${TAG:?TAG is required}"
 VERSION=$(echo "$TAG" | sed 's/^v//')
+
+# Determine npm dist-tag: pre-release versions get a named tag, stable gets "latest"
+if [[ "$VERSION" == *-* ]]; then
+  PRERELEASE="${VERSION#*-}"
+  # Extract the identifier before any dot/number (e.g. "nightly", "alpha", "rc")
+  NPM_TAG=$(echo "$PRERELEASE" | sed 's/[^a-zA-Z].*//')
+  NPM_TAG="${NPM_TAG:-next}"
+else
+  NPM_TAG="latest"
+fi
 
 declare -A PLATFORM_MAP
 PLATFORM_MAP[linux-x64-musl]="linux-x64"
@@ -62,7 +74,7 @@ for platform in linux-x64-musl linux-arm64-musl macos-arm64 macos-x86 windows-x6
 }
 EOF
   cd "${PKG_DIR}"
-  npm publish --access public --provenance
+  npm publish --access public --provenance --tag "$NPM_TAG"
   cd -
 done
 
@@ -95,4 +107,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cp "${SCRIPT_DIR}/npm_postinstall.js" ./npm-root/postinstall.js
 
 cd ./npm-root
-npm publish --access public
+npm publish --access public --tag "$NPM_TAG"

--- a/scripts/ci/publish_pypi.sh
+++ b/scripts/ci/publish_pypi.sh
@@ -3,9 +3,32 @@ set -euo pipefail
 
 # Builds platform-specific wheels and publishes to PyPI using trusted publishing.
 # Required env: TAG, GH_TOKEN
+# Supports pre-release tags (e.g. v0.0.0-nightly, v0.0.0-alpha.1, v0.0.0-rc.1)
+# by converting semver pre-release identifiers to PEP 440 format.
 
 TAG="${TAG:?TAG is required}"
-VERSION=$(echo "$TAG" | sed 's/^v//')
+SEMVER=$(echo "$TAG" | sed 's/^v//')
+
+# Convert semver pre-release to PEP 440
+# e.g. 0.0.0-nightly -> 0.0.0.dev0, 0.0.0-alpha.1 -> 0.0.0a1,
+#      0.0.0-beta.2 -> 0.0.0b2, 0.0.0-rc.1 -> 0.0.0rc1
+if [[ "$SEMVER" == *-* ]]; then
+  BASE_VERSION="${SEMVER%%-*}"
+  PRERELEASE="${SEMVER#*-}"
+
+  if [[ "$PRERELEASE" =~ ^alpha\.?([0-9]*)$ ]]; then
+    VERSION="${BASE_VERSION}a${BASH_REMATCH[1]:-0}"
+  elif [[ "$PRERELEASE" =~ ^beta\.?([0-9]*)$ ]]; then
+    VERSION="${BASE_VERSION}b${BASH_REMATCH[1]:-0}"
+  elif [[ "$PRERELEASE" =~ ^rc\.?([0-9]*)$ ]]; then
+    VERSION="${BASE_VERSION}rc${BASH_REMATCH[1]:-0}"
+  else
+    # Generic pre-release (nightly, test, dev, etc.) -> .dev0
+    VERSION="${BASE_VERSION}.dev0"
+  fi
+else
+  VERSION="$SEMVER"
+fi
 PKG_NAME="py_dotagents"
 DIST_NAME="py-dotagents"
 

--- a/scripts/ci/update_homebrew.sh
+++ b/scripts/ci/update_homebrew.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 # Updates the Homebrew formula with new version and SHA256 hashes.
 # Required env: TAG, RELEASE_PAT, SHA_ARM64, SHA_X86
+# Pre-release tags (e.g. v0.0.0-nightly) update Formula/dotagents-nightly.rb
+# instead of the stable Formula/dotagents.rb.
 
 TAG="${TAG:?TAG is required}"
 VERSION=$(echo "$TAG" | sed 's/^v//')
@@ -10,15 +12,29 @@ RELEASE_PAT="${RELEASE_PAT:?RELEASE_PAT is required}"
 SHA_ARM64="${SHA_ARM64:?SHA_ARM64 is required}"
 SHA_X86="${SHA_X86:?SHA_X86 is required}"
 
+# Determine which formula to update
+if [[ "$VERSION" == *-* ]]; then
+  FORMULA="Formula/dotagents-nightly.rb"
+  COMMIT_MSG="chore: update dotagents-nightly to v${VERSION}"
+else
+  FORMULA="Formula/dotagents.rb"
+  COMMIT_MSG="chore: update dotagents to v${VERSION}"
+fi
+
 git clone "https://x-access-token:${RELEASE_PAT}@github.com/soorya-u/homebrew-dotagents.git"
 cd homebrew-dotagents
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-sed -i "s/version \".*\"/version \"${VERSION}\"/" Formula/dotagents.rb
-sed -i "0,/sha256 \".*\"/s//sha256 \"${SHA_ARM64}\"/" Formula/dotagents.rb
-sed -i "0,/sha256 \".*\"/!{0,/sha256 \".*\"/s//sha256 \"${SHA_X86}\"/}" Formula/dotagents.rb
+if [ ! -f "$FORMULA" ]; then
+  echo "Warning: ${FORMULA} not found in tap, skipping Homebrew update"
+  exit 0
+fi
+
+sed -i "s/version \".*\"/version \"${VERSION}\"/" "$FORMULA"
+sed -i "0,/sha256 \".*\"/s//sha256 \"${SHA_ARM64}\"/" "$FORMULA"
+sed -i "0,/sha256 \".*\"/!{0,/sha256 \".*\"/s//sha256 \"${SHA_X86}\"/}" "$FORMULA"
 
 git add -A
-git commit -m "chore: update dotagents to v${VERSION}"
+git commit -m "$COMMIT_MSG"
 git push origin main

--- a/scripts/ci/update_homebrew.sh
+++ b/scripts/ci/update_homebrew.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # Updates the Homebrew formula with new version and SHA256 hashes.
 # Required env: TAG, RELEASE_PAT, SHA_ARM64, SHA_X86
-# Pre-release tags (e.g. v0.0.0-nightly) update Formula/dotagents-nightly.rb
-# instead of the stable Formula/dotagents.rb.
+# Pre-release tags (e.g. v0.0.0-nightly, v0.0.0-alpha.1, v0.0.0-rc.1) update
+# a channel-specific formula (e.g. Formula/dotagents-nightly.rb) instead of stable.
 
 TAG="${TAG:?TAG is required}"
 VERSION=$(echo "$TAG" | sed 's/^v//')
@@ -12,10 +12,13 @@ RELEASE_PAT="${RELEASE_PAT:?RELEASE_PAT is required}"
 SHA_ARM64="${SHA_ARM64:?SHA_ARM64 is required}"
 SHA_X86="${SHA_X86:?SHA_X86 is required}"
 
-# Determine which formula to update
+# Determine which formula to update based on pre-release channel
 if [[ "$VERSION" == *-* ]]; then
-  FORMULA="Formula/dotagents-nightly.rb"
-  COMMIT_MSG="chore: update dotagents-nightly to v${VERSION}"
+  PRERELEASE="${VERSION#*-}"
+  CHANNEL=$(echo "$PRERELEASE" | sed 's/[^a-zA-Z].*//')
+  CHANNEL="${CHANNEL:-prerelease}"
+  FORMULA="Formula/dotagents-${CHANNEL}.rb"
+  COMMIT_MSG="chore: update dotagents-${CHANNEL} to v${VERSION}"
 else
   FORMULA="Formula/dotagents.rb"
   COMMIT_MSG="chore: update dotagents to v${VERSION}"

--- a/scripts/ci/update_scoop.sh
+++ b/scripts/ci/update_scoop.sh
@@ -3,18 +3,21 @@ set -euo pipefail
 
 # Updates the Scoop manifest with new version and SHA256 hash.
 # Required env: TAG, RELEASE_PAT, SHA_HASH
-# Pre-release tags (e.g. v0.0.0-nightly) update bucket/dotagents-nightly.json
-# instead of the stable bucket/dotagents.json.
+# Pre-release tags (e.g. v0.0.0-nightly, v0.0.0-alpha.1, v0.0.0-rc.1) update
+# a channel-specific manifest (e.g. bucket/dotagents-nightly.json) instead of stable.
 
 TAG="${TAG:?TAG is required}"
 VERSION=$(echo "$TAG" | sed 's/^v//')
 RELEASE_PAT="${RELEASE_PAT:?RELEASE_PAT is required}"
 SHA_HASH="${SHA_HASH:?SHA_HASH is required}"
 
-# Determine which manifest to update
+# Determine which manifest to update based on pre-release channel
 if [[ "$VERSION" == *-* ]]; then
-  MANIFEST="bucket/dotagents-nightly.json"
-  COMMIT_MSG="chore: update dotagents-nightly to v${VERSION}"
+  PRERELEASE="${VERSION#*-}"
+  CHANNEL=$(echo "$PRERELEASE" | sed 's/[^a-zA-Z].*//')
+  CHANNEL="${CHANNEL:-prerelease}"
+  MANIFEST="bucket/dotagents-${CHANNEL}.json"
+  COMMIT_MSG="chore: update dotagents-${CHANNEL} to v${VERSION}"
 else
   MANIFEST="bucket/dotagents.json"
   COMMIT_MSG="chore: update dotagents to v${VERSION}"

--- a/scripts/ci/update_scoop.sh
+++ b/scripts/ci/update_scoop.sh
@@ -3,22 +3,38 @@ set -euo pipefail
 
 # Updates the Scoop manifest with new version and SHA256 hash.
 # Required env: TAG, RELEASE_PAT, SHA_HASH
+# Pre-release tags (e.g. v0.0.0-nightly) update bucket/dotagents-nightly.json
+# instead of the stable bucket/dotagents.json.
 
 TAG="${TAG:?TAG is required}"
 VERSION=$(echo "$TAG" | sed 's/^v//')
 RELEASE_PAT="${RELEASE_PAT:?RELEASE_PAT is required}"
 SHA_HASH="${SHA_HASH:?SHA_HASH is required}"
 
+# Determine which manifest to update
+if [[ "$VERSION" == *-* ]]; then
+  MANIFEST="bucket/dotagents-nightly.json"
+  COMMIT_MSG="chore: update dotagents-nightly to v${VERSION}"
+else
+  MANIFEST="bucket/dotagents.json"
+  COMMIT_MSG="chore: update dotagents to v${VERSION}"
+fi
+
 git clone "https://x-access-token:${RELEASE_PAT}@github.com/soorya-u/scoop-dotagents.git"
 cd scoop-dotagents
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+if [ ! -f "$MANIFEST" ]; then
+  echo "Warning: ${MANIFEST} not found in bucket, skipping Scoop update"
+  exit 0
+fi
+
 jq --arg version "$VERSION" --arg hash "$SHA_HASH" \
   '.version = $version | .architecture."64bit".hash = $hash | .architecture."64bit".url = "https://github.com/soorya-u/dotagents/releases/download/v\($version)/dotagents-windows-x64.exe"' \
-  bucket/dotagents.json > bucket/dotagents.json.tmp
-mv bucket/dotagents.json.tmp bucket/dotagents.json
+  "$MANIFEST" > "${MANIFEST}.tmp"
+mv "${MANIFEST}.tmp" "$MANIFEST"
 
 git add -A
-git commit -m "chore: update dotagents to v${VERSION}"
+git commit -m "$COMMIT_MSG"
 git push origin main


### PR DESCRIPTION
## Summary

- GitHub Releases are now marked as prerelease when the tag contains a hyphen (e.g. `v0.0.0-nightly`)
- npm publishes pre-release versions under a named dist-tag (e.g. `nightly`, `alpha`, `rc`) instead of `latest`
- PyPI publishes convert semver pre-release identifiers to PEP 440 format (`a`, `b`, `rc`, `.dev0`)
- Homebrew and Scoop updates now target separate nightly formula/manifest for pre-releases, leaving stable taps unchanged

## Testing

- `prerelease` flag in `release.yml`: verified with a tag containing `-` via action expression logic — Not run
- `publish_npm.sh` dist-tag logic: manually tested on test tags — Not run
- `publish_pypi.sh` PEP 440 conversion: ran conversions for `nightly`, `alpha.1`, `beta.2`, `rc.1` against expected output — Not run
- `update_homebrew.sh` / `update_scoop.sh`: checked file existence guard and correct formula/manifest selection for pre-release vs stable tags — Not run
- Full end-to-end pipeline requires triggering the workflow with a pre-release tag on a real release — Not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to distinguish between stable and pre-release versions across all package managers.
  * Pre-release versions now publish to dedicated nightly/next distribution channels on NPM, Homebrew, and Scoop.
  * Python packages now use PEP 440-compliant formatting for pre-release version identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->