### PR TITLE
Add OpenSpec proposals for config, providers, and JSON/full-flag features

### DIFF
--- a/openspec/changes/add-config-command/.openspec.yaml
+++ b/openspec/changes/add-config-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/add-config-command/design.md
+++ b/openspec/changes/add-config-command/design.md
@@ -1,0 +1,43 @@
+## Context
+
+Dotagents has a layered config system: `config.toml` (global), `local.config.toml` (overrides), and `AppConfig` (runtime merge). Users edit these files manually with TOML but have no way to inspect the resolved configuration. TUI tools like `cliclack` enable interactive inspection and editing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Display the resolved AppConfig (active features, targeted providers, per-feature settings)
+- Support inspecting individual config layers (`global`, `local`)
+- `--json` flag for machine-readable config
+- `--edit` flag for interactive TUI editing of `global` and `local` configs
+- CLI mode for non-interactive environments
+
+**Non-Goals:**
+- Editing `app` config (it's derived, not persisted)
+- Schema validation or linting of config values
+- Real-time watch/reload of config
+
+## Decisions
+
+### Subcommand argument: `app` as default
+`dotagents config` defaults to showing the merged AppConfig. `dotagents config app` is an explicit alias. `dotagents config global` and `dotagents config local` show individual layers. This hierarchy matches user mental model: "show me what's applied" is the primary use case.
+
+### `--edit` only on global/local, not app
+AppConfig is computed at runtime from the merge of global+local. Editing it directly makes no sense — changes would have nowhere to persist. The CLI rejects `--edit` on `app` with a clear error.
+
+### TUI editor: cliclack multiselect + form prompts
+Editing uses cliclack:
+- **Features**: multiselect from `["commands", "instructions", "mcp", "skills"]`
+- **Providers**: multiselect from registry names + any custom providers in current config, with an option to type new custom names
+- After selection, writes the chosen features as `features = [...]` and providers as `targets = [...]` in the appropriate TOML file
+- Provider `FeatureSettings` editing (template, target, variables) is deferred to a future change for scope control
+
+### JSON output uses existing serde serialization
+`GlobalConfig`, `LocalConfig`, and `AppConfig` already derive `Serialize`. `--json` serializes the selected config layer directly. For `app`, a display-friendly structure is built at runtime merging features and provider settings.
+
+### CLI mode for non-TTY environments
+When stdin is not a TTY, the command outputs a plain-text listing without interactive prompts. `--edit` in non-TTY is rejected with a message directing users to a TTY.
+
+## Risks / Trade-offs
+
+- **Editing scope creep**: Full FeatureSettings editing (template, target paths) in TUI is complex. → Deferred; the TUI editor handles features and targets (provider selection) only, which covers the 80% use case.
+- **Config file write conflicts**: If a user manually edits config while the TUI editor is open, changes may be lost. → The editor reads at open time and writes atomically (write to temp file, then rename). A warning is shown if the file was modified since read.

--- a/openspec/changes/add-config-command/proposal.md
+++ b/openspec/changes/add-config-command/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Dotagents uses a layered config system (global `config.toml`, local `local.config.toml`, merged `AppConfig`) but users have no way to inspect their resolved runtime configuration. After init and any edits, users are left guessing which features are active, which providers are targeted, and how local overrides have merged with global settings. A `config` command closes this visibility gap.
+
+## What Changes
+
+- Add a `dotagents config` subcommand (defaulting to `app` — the merged runtime config)
+- Support `dotagents config app|global|local` to inspect each configuration layer individually
+- CLI mode: display active features and targeted providers with their settings
+- `--json` flag outputs the selected config as structured JSON
+- TUI mode: interactive viewer for `app`/`global`/`local` configs with detail navigation
+- `--edit` flag (only on `global` or `local`): opens an interactive TUI editor to add, remove, or modify providers and features; edits are persisted to the respective config file
+- `--edit` on `app` is rejected with an error (app is derived, not directly editable)
+
+## Capabilities
+
+### New Capabilities
+- `config-inspect`: viewing and interactively editing the workspace configuration (global, local, and merged app config)
+
+### Modified Capabilities
+<!-- None -->
+
+## Impact
+
+- `src/cli/config.rs` — new module implementing the `config` subcommand and TUI editor
+- `src/cli/options.rs` — new `Action::Config` variant with `ConfigAction` enum
+- `src/schema/config/` — may need minor additions for display-friendly config serialization
+- `tests/e2e/` — new e2e tests for CLI and TUI paths

--- a/openspec/changes/add-config-command/specs/config-inspect/spec.md
+++ b/openspec/changes/add-config-command/specs/config-inspect/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: config command shows the merged AppConfig by default
+`dotagents config` or `dotagents config app` SHALL load the workspace configuration, compute the merged AppConfig, and display the active features and targeted providers with their per-feature settings. If no workspace is found, the command SHALL exit 1 with an error referencing `dotagents init`.
+
+#### Scenario: Merged config with features and providers displayed
+- **WHEN** `dotagents config` is run in a workspace with `features = ["commands", "mcp"]` and `targets = ["claude", "cursor"]`
+- **THEN** the active features and each provider's feature settings (template, target, disabled status, variables) are displayed and the command exits 0
+
+#### Scenario: Empty config displayed
+- **WHEN** `dotagents config` is run in a workspace with no features and no targets
+- **THEN** a message indicating no features or providers are configured is displayed and the command exits 0
+
+#### Scenario: Missing workspace exits with error
+- **WHEN** no `.dotagents/` directory exists in the current or any parent directory
+- **THEN** the command exits 1 with an error referencing `dotagents init`
+
+### Requirement: config global shows the global config file
+`dotagents config global` SHALL read and display the contents of `config.toml` — features, targets, providers, variables, and package_runner. No merging with local config occurs.
+
+#### Scenario: Global config displayed
+- **WHEN** `dotagents config global` is run and `config.toml` contains `features = ["commands"]` and `targets = ["claude"]`
+- **THEN** those values are displayed and the command exits 0
+
+#### Scenario: Missing global config errors
+- **WHEN** `config.toml` does not exist in the workspace
+- **THEN** the command exits 1 with an error indicating the config file is missing
+
+### Requirement: config local shows the local config file
+`dotagents config local` SHALL read and display the contents of `local.config.toml`. If the file does not exist, the command SHALL output a message indicating no local config exists and exit 0.
+
+#### Scenario: Local config with overrides displayed
+- **WHEN** `dotagents config local` is run and `local.config.toml` contains overrides for features and targets
+- **THEN** those overrides are displayed and the command exits 0
+
+#### Scenario: Missing local config shows informational message
+- **WHEN** `local.config.toml` does not exist
+- **THEN** a message indicating no local config exists is displayed and the command exits 0
+
+### Requirement: --json flag outputs config as structured JSON
+When `--json` is passed, `dotagents config [app|global|local]` SHALL output the selected config serialized as JSON. For `app`, the output SHALL be a flat structure with `features` (array of strings) and `providers` (array of objects with provider name and per-feature settings). For `global` and `local`, the output SHALL use the existing TOML-derived JSON serialization.
+
+#### Scenario: App config as JSON
+- **WHEN** `dotagents config app --json` is run
+- **THEN** stdout contains valid JSON with `features` and `providers` top-level keys
+
+#### Scenario: Global config as JSON
+- **WHEN** `dotagents config global --json` is run
+- **THEN** stdout contains valid JSON representing the full global config
+
+### Requirement: CLI mode displays plain-text config summary
+When stdin is not a TTY and `--json` is not passed, the config command SHALL output a plain-text summary of the config (features list and providers table). No interactive prompts SHALL be shown.
+
+#### Scenario: Non-TTY output is plain text
+- **WHEN** stdin is not a TTY and `dotagents config` is run
+- **THEN** a plain-text listing of features and providers is output and the command exits 0
+
+### Requirement: TUI mode provides interactive config viewer
+When stdin is a TTY and `--json` is not passed, the config command SHALL display an interactive TUI that allows navigating the config details. The TUI SHALL show features with their enabled/disabled status and providers with their per-feature settings.
+
+#### Scenario: TUI shows config in interactive view
+- **WHEN** `dotagents config` is run in a TTY
+- **THEN** a cliclack-based interactive view displays the config with navigable sections for features and providers
+
+### Requirement: --edit flag enables TUI editing for global and local configs
+When `--edit` is passed with `global` or `local`, the command SHALL open an interactive TUI editor that allows the user to add or remove features and providers. Changes SHALL be persisted to the respective config file. When `--edit` is passed with `app`, the command SHALL error.
+
+#### Scenario: Edit global config features
+- **WHEN** `dotagents config global --edit` is run in a TTY
+- **THEN** an interactive prompt lets the user toggle features and select providers; changes are written to `config.toml`
+
+#### Scenario: Edit local config providers
+- **WHEN** `dotagents config local --edit` is run in a TTY
+- **THEN** an interactive prompt lets the user modify overrides; changes are written to `local.config.toml`
+
+#### Scenario: --edit on app config errors
+- **WHEN** `dotagents config app --edit` or `dotagents config --edit` is run
+- **THEN** the command exits 1 with an error explaining that app config is derived and cannot be edited directly
+
+#### Scenario: --edit in non-TTY mode errors
+- **WHEN** `dotagents config global --edit` is run and stdin is not a TTY
+- **THEN** the command exits 1 with an error directing the user to run in a TTY
+
+### Requirement: config command is read-only by default
+Without `--edit`, the config command SHALL NOT modify any files. It SHALL only read config files and display their content.
+
+#### Scenario: Config display does not modify files
+- **WHEN** `dotagents config` completes successfully without `--edit`
+- **THEN** no files in `.dotagents/` or workspace are modified compared to before the command ran

--- a/openspec/changes/add-config-command/specs/config-inspect/spec.md
+++ b/openspec/changes/add-config-command/specs/config-inspect/spec.md
@@ -86,4 +86,4 @@ Without `--edit`, the config command SHALL NOT modify any files. It SHALL only r
 
 #### Scenario: Config display does not modify files
 - **WHEN** `dotagents config` completes successfully without `--edit`
-- **THEN** no files in `.dotagents/` or workspace are modified compared to before the command ran
+- **THEN** no files in `.dotagents/`, workspace, or any global config paths read by the command are modified compared to before the command ran

--- a/openspec/changes/add-config-command/tasks.md
+++ b/openspec/changes/add-config-command/tasks.md
@@ -1,0 +1,47 @@
+## 1. CLI plumbing
+
+- [ ] 1.1 Add `Config` variant to `Action` enum and `ConfigAction` enum in `src/cli/options.rs`
+- [ ] 1.2 Define `ConfigTarget` enum: `App` (default), `Global`, `Local`
+- [ ] 1.3 Create `src/cli/config.rs` module with `handle` function
+- [ ] 1.4 Wire `Action::Config` dispatch in `src/cli/runner.rs`
+- [ ] 1.5 Add `--json` flag to config command
+- [ ] 1.6 Add `--edit` flag (only valid for `global`/`local` targets)
+
+## 2. Core implementation
+
+- [ ] 2.1 Implement workspace/config loading for config command (reuse existing `get_workspace_dir` and config loading)
+- [ ] 2.2 Implement CLI text output: display active features and providers for `app` target
+- [ ] 2.3 Implement CLI text output: display raw config content for `global`/`local` targets
+- [ ] 2.4 Implement `--json` output using existing serde serialization for all three targets
+- [ ] 2.5 Implement `--edit` validation: reject `--edit` on `app`, reject `--edit` in non-TTY
+- [ ] 2.6 Implement TUI viewer mode (cliclack interactive display of config sections)
+- [ ] 2.7 Implement TUI editor mode for `global --edit`: multiselect features + provider selection + write to config.toml
+- [ ] 2.8 Implement TUI editor mode for `local --edit`: same as global but writes to local.config.toml
+
+## 3. Display-friendly config serialization
+
+- [ ] 3.1 Add `AppConfig::to_display_json()` method returning a flat `{ features: [...], providers: [...] }` structure
+- [ ] 3.2 Implement provider detail extraction from `AppConfig` (name, enabled features, per-feature settings)
+
+## 4. Unit tests
+
+- [ ] 4.1 Test config target parsing (app/global/local from CLI args)
+- [ ] 4.2 Test `--edit` rejection on `app` target
+- [ ] 4.3 Test `--edit` rejection in non-TTY mode
+- [ ] 4.4 Test `AppConfig::to_display_json()` output format
+
+## 5. E2E tests
+
+- [ ] 5.1 tui-devtools discovery pass for `config` TUI viewer flow
+- [ ] 5.2 tui-devtools discovery pass for `config global --edit` TUI editor flow
+- [ ] 5.3 Add e2e test: `dotagents config` CLI output in non-TTY
+- [ ] 5.4 Add e2e test: `dotagents config --json` valid JSON output
+- [ ] 5.5 Add e2e test: `dotagents config global --json` valid JSON output
+- [ ] 5.6 Add e2e test: `dotagents config app --edit` errors correctly
+- [ ] 5.7 Add e2e test: `dotagents config global --edit` in TTY mode
+- [ ] 5.8 Add e2e test: `dotagents config` TUI viewer mode
+
+## 6. Verification
+
+- [ ] 6.1 Run `mise check` and fix any format/lint issues
+- [ ] 6.2 Run `mise tests` and fix any failures

--- a/openspec/changes/add-json-full-flags/.openspec.yaml
+++ b/openspec/changes/add-json-full-flags/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/add-json-full-flags/design.md
+++ b/openspec/changes/add-json-full-flags/design.md
@@ -22,8 +22,8 @@ Each feature type (Command, Skill) already implements `to_value()` which returns
 ### `--full` extends existing flag, includes body content
 The `--full` flag already exists in both `commands ls` and `skills ls` specs for showing full descriptions. This change extends it to also include the full markdown body content (`content` / `body`). When `--full` is absent, only name + frontmatter fields (description, category, tags, etc.) are shown.
 
-### JSON output includes body content unconditionally; `--full` is a no-op in JSON mode
-When `--json` is active, the full `to_value()` representation is serialized, which naturally includes body content. When both `--json` and `--full` are passed, `--json` takes precedence: JSON output is produced, and `--full` has no additional effect on the JSON structure since body content is already included by `to_value()`. `--full` only affects human-readable CLI text output when `--json` is absent.
+### `--json` alone outputs frontmatter only; `--full` adds body content when combined
+When `--json` is active without `--full`, the output includes frontmatter fields only (name, description, category, tags). Body content is omitted. When both `--json` and `--full` are passed, each JSON object gains a `content` key containing the raw markdown body string. When `--json` is absent, `--full` only affects the human-readable CLI text output by including body content after frontmatter.
 
 ### CLI-only; TUI output unchanged
 These flags affect CLI text/JSON output. The existing TUI list display (if any) is not modified. In non-TTY mode, text output includes the formatted content; in JSON mode, JSON is emitted.

--- a/openspec/changes/add-json-full-flags/design.md
+++ b/openspec/changes/add-json-full-flags/design.md
@@ -1,0 +1,37 @@
+## Context
+
+`commands ls` and `skills ls` display name + truncated description via cliclack output. Users need two additional output modes: machine-readable JSON for scripting, and full body content for detailed inspection. These flags establish a pattern for future read-only list commands.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `--json` flag: output `commands ls` and `skills ls` as structured JSON using `to_value()`
+- `--full` flag: include the full markdown body content in output (extends existing behavior)
+- Establish a consistent flag pattern for read-only list commands
+
+**Non-Goals:**
+- Changing default output format (remains name + description)
+- Adding `--json` to mutation commands (`new`, `rm`, `add`)
+- Per-item detail subcommands (future work)
+
+## Decisions
+
+### `--json` uses `FeatureTrait::to_value()` natively
+Each feature type (Command, Skill) already implements `to_value()` which returns `serde_json::Value`. The `--json` flag collects all features into a `Vec<Value>` and serializes as a single JSON array. This avoids defining a parallel output schema and ensures consistency with template rendering.
+
+### `--full` extends existing flag, includes body content
+The `--full` flag already exists in both `commands ls` and `skills ls` specs for showing full descriptions. This change extends it to also include the full markdown body content (`content` / `body`). When `--full` is absent, only name + frontmatter fields (description, category, tags, etc.) are shown.
+
+### JSON output includes body content unconditionally
+When `--json` is active, the full `to_value()` representation is serialized, which naturally includes body content. The `--full` flag is orthogonal in JSON mode — it affects the CLI text display but not the JSON structure.
+
+### CLI-only; TUI output unchanged
+These flags affect CLI text/JSON output. The existing TUI list display (if any) is not modified. In non-TTY mode, text output includes the formatted content; in JSON mode, JSON is emitted.
+
+### Flag names are reusable across commands
+`--json` and `--full` use the same flag definitions across `commands ls` and `skills ls`. This establishes a pattern: any future read-only list command (e.g., `providers ls --json`) uses the same flag convention.
+
+## Risks / Trade-offs
+
+- **Large body content in terminal**: `--full` without a pager could flood the terminal for long commands/skills. → Acceptable; users explicitly opt in. A future enhancement could pipe through `less` but that's out of scope.
+- **JSON output volume**: Full body content in JSON could be large. → The `--json` output is inherently machine-readable; consumers can filter as needed.

--- a/openspec/changes/add-json-full-flags/design.md
+++ b/openspec/changes/add-json-full-flags/design.md
@@ -22,8 +22,8 @@ Each feature type (Command, Skill) already implements `to_value()` which returns
 ### `--full` extends existing flag, includes body content
 The `--full` flag already exists in both `commands ls` and `skills ls` specs for showing full descriptions. This change extends it to also include the full markdown body content (`content` / `body`). When `--full` is absent, only name + frontmatter fields (description, category, tags, etc.) are shown.
 
-### JSON output includes body content unconditionally
-When `--json` is active, the full `to_value()` representation is serialized, which naturally includes body content. The `--full` flag is orthogonal in JSON mode — it affects the CLI text display but not the JSON structure.
+### JSON output includes body content unconditionally; `--full` is a no-op in JSON mode
+When `--json` is active, the full `to_value()` representation is serialized, which naturally includes body content. When both `--json` and `--full` are passed, `--json` takes precedence: JSON output is produced, and `--full` has no additional effect on the JSON structure since body content is already included by `to_value()`. `--full` only affects human-readable CLI text output when `--json` is absent.
 
 ### CLI-only; TUI output unchanged
 These flags affect CLI text/JSON output. The existing TUI list display (if any) is not modified. In non-TTY mode, text output includes the formatted content; in JSON mode, JSON is emitted.

--- a/openspec/changes/add-json-full-flags/proposal.md
+++ b/openspec/changes/add-json-full-flags/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`commands ls` and `skills ls` currently only show truncated name + description. Users scripting dotagents need machine-readable output (`--json`), and users inspecting content need the full body (`--full` including markdown body, not just frontmatter). These flags standardize output across read-only commands.
+
+## What Changes
+
+- Add `--json` flag to `dotagents commands ls` and `dotagents skills ls` — outputs using each feature's `to_value()` representation
+- Add `--full` flag to `dotagents commands ls` and `dotagents skills ls` — includes the full markdown body content in addition to frontmatter metadata
+- Without `--full`, only the command/skill name and frontmatter metadata are shown (current behavior, made explicit)
+- The `--full` flag already exists in both `commands ls` and `skills ls` specs but only covers descriptions; this extends it to also include body content
+- Both flags are designed to be applicable to any future read-only list commands
+
+## Capabilities
+
+### New Capabilities
+- `cli-output-formats`: standardised `--json` and `--full` flags for read-only list commands, providing machine-readable JSON output and verbose body-inclusive display
+
+### Modified Capabilities
+- `commands-subcommand`: `commands ls` gains `--json` flag and `--full` is extended to include body content
+- `skills-subcommand-extended`: `skills ls` gains `--json` flag and `--full` is extended to include body content
+
+## Impact
+
+- `src/cli/commands.rs` — `ls` subcommand gains `--json` and extended `--full` flags
+- `src/cli/skills.rs` — `ls` subcommand gains `--json` and extended `--full` flags
+- `src/schema/features/` — may need additional serialization support for JSON output
+- `tests/e2e/` — new e2e tests covering CLI and TUI paths with both flags

--- a/openspec/changes/add-json-full-flags/specs/cli-output-formats/spec.md
+++ b/openspec/changes/add-json-full-flags/specs/cli-output-formats/spec.md
@@ -42,7 +42,7 @@ The `--json` and `--full` flags SHALL be independent and combinable. When both a
 - **THEN** the text output includes the full body content of each command after the frontmatter
 
 ### Requirement: JSON output is valid and parseable
-JSON output from `--json` SHALL be valid JSON that can be piped to tools like `jq`. Each object SHALL include at least `name` and `content` (body) fields, with optional frontmatter-extracted fields. The output SHALL NOT include any non-JSON text (e.g., status messages, warnings) on stdout.
+JSON output from `--json` SHALL be valid JSON that can be piped to tools like `jq`. Each object SHALL include at least a stable identifier field (e.g., `name` or `slug`). The `content` field (body) is included when the feature type has body content (e.g., commands, skills), as returned by `to_value()`. For commands that have no body (e.g., `providers ls`), `content` may be absent. The output SHALL NOT include any non-JSON text (e.g., status messages, warnings) on stdout.
 
 #### Scenario: JSON output is pipeable to jq
 - **WHEN** `dotagents commands ls --json | jq '.[0].name'` is run

--- a/openspec/changes/add-json-full-flags/specs/cli-output-formats/spec.md
+++ b/openspec/changes/add-json-full-flags/specs/cli-output-formats/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: --json flag outputs list as structured JSON
+When `--json` is passed to a read-only list command (`commands ls`, `skills ls`), the command SHALL serialize each item using its `to_value()` representation and output the collection as a JSON array on stdout. All log/warning output SHALL go to stderr.
+
+#### Scenario: commands ls --json outputs command data
+- **WHEN** `dotagents commands ls --json` is run in a workspace with two commands
+- **THEN** stdout contains a JSON array with two objects, each containing the command's frontmatter fields (name, description, category, tags) and body content
+
+#### Scenario: skills ls --json outputs skill data
+- **WHEN** `dotagents skills ls --json` is run in a workspace with one skill
+- **THEN** stdout contains a JSON array with one object containing the skill's frontmatter fields and body content
+
+#### Scenario: --json with empty workspace outputs empty array
+- **WHEN** `dotagents commands ls --json` is run with no commands present
+- **THEN** stdout contains `[]` and the command exits 0
+
+### Requirement: --full flag includes body content in output
+When `--full` is passed to `commands ls` or `skills ls`, the command SHALL include the full markdown body content of each item in the output, in addition to the frontmatter fields already shown. Without `--full`, only the name and frontmatter fields SHALL be shown (current behavior).
+
+#### Scenario: --full shows command body content in CLI mode
+- **WHEN** `dotagents commands ls --full` is run in non-TTY mode
+- **THEN** each command's full markdown body content is displayed after its name and frontmatter fields
+
+#### Scenario: --full shows skill body content in CLI mode
+- **WHEN** `dotagents skills ls --full` is run in non-TTY mode
+- **THEN** each skill's full markdown body content is displayed after its name and frontmatter fields
+
+#### Scenario: Without --full, body content is omitted
+- **WHEN** `dotagents commands ls` is run without `--full`
+- **THEN** only name and frontmatter fields (description, category, tags) are displayed; body content is not shown
+
+### Requirement: --json and --full are independent and can be combined
+The `--json` and `--full` flags SHALL be independent and combinable. When both are passed, the JSON output SHALL include body content in the serialized representation (which `to_value()` already includes natively). When `--json` is not passed but `--full` is, body content SHALL be included in the human-readable text output.
+
+#### Scenario: --json --full outputs JSON with body content
+- **WHEN** `dotagents commands ls --json --full` is run
+- **THEN** stdout contains a JSON array where each object includes the body content (same as `--json` alone, since `to_value()` already includes body)
+
+#### Scenario: --full without --json shows body in text output
+- **WHEN** `dotagents commands ls --full` is run without `--json`
+- **THEN** the text output includes the full body content of each command after the frontmatter
+
+### Requirement: JSON output is valid and parseable
+JSON output from `--json` SHALL be valid JSON that can be piped to tools like `jq`. Each object SHALL include at least `name` and `content` (body) fields, with optional frontmatter-extracted fields. The output SHALL NOT include any non-JSON text (e.g., status messages, warnings) on stdout.
+
+#### Scenario: JSON output is pipeable to jq
+- **WHEN** `dotagents commands ls --json | jq '.[0].name'` is run
+- **THEN** `jq` successfully parses the output and extracts the first command's name
+
+### Requirement: Flag convention applies to future read-only list commands
+Any future read-only list command (e.g., `providers ls`) SHALL also support `--json` and `--full` flags with the same semantics: `--json` for machine-readable JSON output via `to_value()`, and `--full` for verbose human-readable output including full content.
+
+#### Scenario: Future read-only command supports --json and --full
+- **WHEN** a new read-only list command is added (e.g., `providers ls`)
+- **THEN** it accepts `--json` and `--full` flags consistent with the pattern established here

--- a/openspec/changes/add-json-full-flags/specs/cli-output-formats/spec.md
+++ b/openspec/changes/add-json-full-flags/specs/cli-output-formats/spec.md
@@ -1,15 +1,15 @@
 ## ADDED Requirements
 
 ### Requirement: --json flag outputs list as structured JSON
-When `--json` is passed to a read-only list command (`commands ls`, `skills ls`), the command SHALL serialize each item using its `to_value()` representation and output the collection as a JSON array on stdout. All log/warning output SHALL go to stderr.
+When `--json` is passed to a read-only list command (`commands ls`, `skills ls`), the command SHALL serialize each item's frontmatter fields and output the collection as a JSON array on stdout. Body content SHALL NOT be included unless `--full` is also passed. All log/warning output SHALL go to stderr.
 
-#### Scenario: commands ls --json outputs command data
+#### Scenario: commands ls --json outputs frontmatter data
 - **WHEN** `dotagents commands ls --json` is run in a workspace with two commands
-- **THEN** stdout contains a JSON array with two objects, each containing the command's frontmatter fields (name, description, category, tags) and body content
+- **THEN** stdout contains a JSON array with two objects, each containing the command's frontmatter fields (name, description, category, tags) without body content
 
-#### Scenario: skills ls --json outputs skill data
+#### Scenario: skills ls --json outputs frontmatter data
 - **WHEN** `dotagents skills ls --json` is run in a workspace with one skill
-- **THEN** stdout contains a JSON array with one object containing the skill's frontmatter fields and body content
+- **THEN** stdout contains a JSON array with one object containing the skill's frontmatter fields without body content
 
 #### Scenario: --json with empty workspace outputs empty array
 - **WHEN** `dotagents commands ls --json` is run with no commands present
@@ -31,18 +31,22 @@ When `--full` is passed to `commands ls` or `skills ls`, the command SHALL inclu
 - **THEN** only name and frontmatter fields (description, category, tags) are displayed; body content is not shown
 
 ### Requirement: --json and --full are independent and can be combined
-The `--json` and `--full` flags SHALL be independent and combinable. When both are passed, the JSON output SHALL include body content in the serialized representation (which `to_value()` already includes natively). When `--json` is not passed but `--full` is, body content SHALL be included in the human-readable text output.
+The `--json` and `--full` flags SHALL be independent and combinable. When both are passed, the JSON output SHALL include frontmatter fields plus a `content` key containing the raw markdown body string. When `--json` is not passed but `--full` is, body content SHALL be included in the human-readable text output.
 
 #### Scenario: --json --full outputs JSON with body content
 - **WHEN** `dotagents commands ls --json --full` is run
-- **THEN** stdout contains a JSON array where each object includes the body content (same as `--json` alone, since `to_value()` already includes body)
+- **THEN** stdout contains a JSON array where each object includes frontmatter fields and a `content` key with the raw markdown body string
+
+#### Scenario: --json alone without --full omits body content
+- **WHEN** `dotagents commands ls --json` is run without `--full`
+- **THEN** stdout contains a JSON array where each object includes frontmatter fields only; the `content` key is absent
 
 #### Scenario: --full without --json shows body in text output
 - **WHEN** `dotagents commands ls --full` is run without `--json`
 - **THEN** the text output includes the full body content of each command after the frontmatter
 
 ### Requirement: JSON output is valid and parseable
-JSON output from `--json` SHALL be valid JSON that can be piped to tools like `jq`. Each object SHALL include at least a stable identifier field (e.g., `name` or `slug`). The `content` field (body) is included when the feature type has body content (e.g., commands, skills), as returned by `to_value()`. For commands that have no body (e.g., `providers ls`), `content` may be absent. The output SHALL NOT include any non-JSON text (e.g., status messages, warnings) on stdout.
+JSON output from `--json` SHALL be valid JSON that can be piped to tools like `jq`. Each object SHALL include at least a stable identifier field (e.g., `name` or `slug`). The `content` field (raw body string) SHALL be included only when `--full` is also passed. For commands that have no body (e.g., `providers ls`), `content` is never present regardless of `--full`. The output SHALL NOT include any non-JSON text (e.g., status messages, warnings) on stdout.
 
 #### Scenario: JSON output is pipeable to jq
 - **WHEN** `dotagents commands ls --json | jq '.[0].name'` is run

--- a/openspec/changes/add-json-full-flags/specs/commands-subcommand/spec.md
+++ b/openspec/changes/add-json-full-flags/specs/commands-subcommand/spec.md
@@ -3,9 +3,9 @@
 ### Requirement: commands ls lists command source files
 `dotagents commands ls` SHALL read commands from `.dotagents/commands/*.md`, parse frontmatter for `name`, `description`, `category`, and `tags`, and display them using cliclack output. Descriptions SHALL be truncated to fit terminal width by default.
 
-When `--json` is passed, the command SHALL output a JSON array of command objects using each command's `to_value()` representation (includes name, frontmatter fields, and body content). All log/warning output SHALL go to stderr.
+When `--json` is passed, the command SHALL output a JSON array of command objects containing frontmatter fields (name, description, category, tags). Body content SHALL NOT be included in JSON output unless `--full` is also passed. All log/warning output SHALL go to stderr.
 
-When `--full` is passed, the command SHALL include the full markdown body content of each command after the frontmatter fields. Without `--full`, only name and frontmatter fields are shown. When both `--json` and `--full` are passed, the `--json` flag takes precedence: JSON output is produced using `to_value()` which already includes body content natively, and `--full` is effectively a no-op in JSON mode.
+When `--full` is passed, the command SHALL include the full markdown body content of each command after the frontmatter fields. Without `--full`, only name and frontmatter fields are shown. When both `--json` and `--full` are passed, each JSON object SHALL include a `content` key with the raw markdown body string in addition to the frontmatter fields.
 
 #### Scenario: Commands listed
 - **WHEN** user runs `dotagents commands ls`
@@ -25,7 +25,7 @@ When `--full` is passed, the command SHALL include the full markdown body conten
 
 #### Scenario: --json outputs commands as JSON array
 - **WHEN** user runs `dotagents commands ls --json`
-- **THEN** stdout contains a JSON array of command objects with name, frontmatter fields, and body content; stderr contains any log messages
+- **THEN** stdout contains a JSON array of command objects with frontmatter fields (name, description, category, tags); body content is absent; stderr contains any log messages
 
 #### Scenario: --json with empty workspace outputs empty array
 - **WHEN** user runs `dotagents commands ls --json` with no commands present

--- a/openspec/changes/add-json-full-flags/specs/commands-subcommand/spec.md
+++ b/openspec/changes/add-json-full-flags/specs/commands-subcommand/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: commands ls lists command source files
+`dotagents commands ls` SHALL read commands from `.dotagents/commands/*.md`, parse frontmatter for `name` and `description`, and display them using cliclack output. Descriptions SHALL be truncated to fit terminal width by default.
+
+When `--json` is passed, the command SHALL output a JSON array of command objects using each command's `to_value()` representation (includes name, frontmatter fields, and body content). All log/warning output SHALL go to stderr.
+
+When `--full` is passed, the command SHALL include the full markdown body content of each command after the frontmatter fields. Without `--full`, only name and frontmatter fields are shown.
+
+#### Scenario: Commands listed
+- **WHEN** user runs `dotagents commands ls`
+- **THEN** all commands found in `.dotagents/commands/` are listed with names and truncated descriptions
+
+#### Scenario: Empty workspace
+- **WHEN** `.dotagents/commands/` is empty or absent
+- **THEN** a message indicating no commands were found is displayed and the command exits 0
+
+#### Scenario: Missing workspace exits with error
+- **WHEN** no `.dotagents/` directory exists in the current or any parent directory
+- **THEN** the command exits 1 with an error referencing `dotagents init`
+
+#### Scenario: --full shows complete descriptions and body content
+- **WHEN** user runs `dotagents commands ls --full`
+- **THEN** each command's full description is shown, word-wrapped at terminal width, followed by the full markdown body content
+
+#### Scenario: --json outputs commands as JSON array
+- **WHEN** user runs `dotagents commands ls --json`
+- **THEN** stdout contains a JSON array of command objects with name, frontmatter fields, and body content; stderr contains any log messages
+
+#### Scenario: --json with empty workspace outputs empty array
+- **WHEN** user runs `dotagents commands ls --json` with no commands present
+- **THEN** stdout contains `[]` and the command exits 0
+
+#### Scenario: Without --full, body content is omitted
+- **WHEN** user runs `dotagents commands ls` without `--full`
+- **THEN** only the command name and frontmatter metadata (description, category, tags) are shown; body content is not displayed

--- a/openspec/changes/add-json-full-flags/specs/commands-subcommand/spec.md
+++ b/openspec/changes/add-json-full-flags/specs/commands-subcommand/spec.md
@@ -1,11 +1,11 @@
 ## MODIFIED Requirements
 
 ### Requirement: commands ls lists command source files
-`dotagents commands ls` SHALL read commands from `.dotagents/commands/*.md`, parse frontmatter for `name` and `description`, and display them using cliclack output. Descriptions SHALL be truncated to fit terminal width by default.
+`dotagents commands ls` SHALL read commands from `.dotagents/commands/*.md`, parse frontmatter for `name`, `description`, `category`, and `tags`, and display them using cliclack output. Descriptions SHALL be truncated to fit terminal width by default.
 
 When `--json` is passed, the command SHALL output a JSON array of command objects using each command's `to_value()` representation (includes name, frontmatter fields, and body content). All log/warning output SHALL go to stderr.
 
-When `--full` is passed, the command SHALL include the full markdown body content of each command after the frontmatter fields. Without `--full`, only name and frontmatter fields are shown.
+When `--full` is passed, the command SHALL include the full markdown body content of each command after the frontmatter fields. Without `--full`, only name and frontmatter fields are shown. When both `--json` and `--full` are passed, the `--json` flag takes precedence: JSON output is produced using `to_value()` which already includes body content natively, and `--full` is effectively a no-op in JSON mode.
 
 #### Scenario: Commands listed
 - **WHEN** user runs `dotagents commands ls`

--- a/openspec/changes/add-json-full-flags/specs/skills-subcommand-extended/spec.md
+++ b/openspec/changes/add-json-full-flags/specs/skills-subcommand-extended/spec.md
@@ -3,9 +3,9 @@
 ### Requirement: skills ls lists local skill source directories
 `dotagents skills ls` SHALL read skills from `.dotagents/skills/*/SKILL.md`, parse frontmatter for `name`, `description`, `license`, and `compatibility`, and display them using cliclack output. Descriptions SHALL be truncated to fit terminal width by default.
 
-When `--json` is passed, the command SHALL output a JSON array of skill objects using each skill's `to_value()` representation (includes name, frontmatter fields, and body content). All log/warning output SHALL go to stderr.
+When `--json` is passed, the command SHALL output a JSON array of skill objects containing frontmatter fields (name, description, license, compatibility). Body content SHALL NOT be included in JSON output unless `--full` is also passed. All log/warning output SHALL go to stderr.
 
-When `--full` is passed, the command SHALL include the full markdown body content of each skill after the frontmatter fields. Without `--full`, only name and frontmatter fields are shown. When both `--json` and `--full` are passed, the `--json` flag takes precedence: JSON output is produced using `to_value()` which already includes body content natively, and `--full` is effectively a no-op in JSON mode.
+When `--full` is passed, the command SHALL include the full markdown body content of each skill after the frontmatter fields. Without `--full`, only name and frontmatter fields are shown. When both `--json` and `--full` are passed, each JSON object SHALL include a `content` key with the raw markdown body string in addition to the frontmatter fields.
 
 #### Scenario: Skills listed
 - **WHEN** user runs `dotagents skills ls`
@@ -25,7 +25,7 @@ When `--full` is passed, the command SHALL include the full markdown body conten
 
 #### Scenario: --json outputs skills as JSON array
 - **WHEN** user runs `dotagents skills ls --json`
-- **THEN** stdout contains a JSON array of skill objects with name, frontmatter fields, and body content; stderr contains any log messages
+- **THEN** stdout contains a JSON array of skill objects with frontmatter fields (name, description, license, compatibility); body content is absent; stderr contains any log messages
 
 #### Scenario: --json with empty workspace outputs empty array
 - **WHEN** user runs `dotagents skills ls --json` with no skills present

--- a/openspec/changes/add-json-full-flags/specs/skills-subcommand-extended/spec.md
+++ b/openspec/changes/add-json-full-flags/specs/skills-subcommand-extended/spec.md
@@ -1,11 +1,11 @@
 ## MODIFIED Requirements
 
 ### Requirement: skills ls lists local skill source directories
-`dotagents skills ls` SHALL read skills from `.dotagents/skills/*/SKILL.md`, parse frontmatter for `name` and `description`, and display them using cliclack output. Descriptions SHALL be truncated to fit terminal width by default.
+`dotagents skills ls` SHALL read skills from `.dotagents/skills/*/SKILL.md`, parse frontmatter for `name`, `description`, `license`, and `compatibility`, and display them using cliclack output. Descriptions SHALL be truncated to fit terminal width by default.
 
 When `--json` is passed, the command SHALL output a JSON array of skill objects using each skill's `to_value()` representation (includes name, frontmatter fields, and body content). All log/warning output SHALL go to stderr.
 
-When `--full` is passed, the command SHALL include the full markdown body content of each skill after the frontmatter fields. Without `--full`, only name and frontmatter fields are shown.
+When `--full` is passed, the command SHALL include the full markdown body content of each skill after the frontmatter fields. Without `--full`, only name and frontmatter fields are shown. When both `--json` and `--full` are passed, the `--json` flag takes precedence: JSON output is produced using `to_value()` which already includes body content natively, and `--full` is effectively a no-op in JSON mode.
 
 #### Scenario: Skills listed
 - **WHEN** user runs `dotagents skills ls`

--- a/openspec/changes/add-json-full-flags/specs/skills-subcommand-extended/spec.md
+++ b/openspec/changes/add-json-full-flags/specs/skills-subcommand-extended/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: skills ls lists local skill source directories
+`dotagents skills ls` SHALL read skills from `.dotagents/skills/*/SKILL.md`, parse frontmatter for `name` and `description`, and display them using cliclack output. Descriptions SHALL be truncated to fit terminal width by default.
+
+When `--json` is passed, the command SHALL output a JSON array of skill objects using each skill's `to_value()` representation (includes name, frontmatter fields, and body content). All log/warning output SHALL go to stderr.
+
+When `--full` is passed, the command SHALL include the full markdown body content of each skill after the frontmatter fields. Without `--full`, only name and frontmatter fields are shown.
+
+#### Scenario: Skills listed
+- **WHEN** user runs `dotagents skills ls`
+- **THEN** all skills found in `.dotagents/skills/` are listed with names and truncated descriptions
+
+#### Scenario: Empty workspace
+- **WHEN** `.dotagents/skills/` is empty or absent
+- **THEN** a message indicating no skills were found is displayed and the command exits 0
+
+#### Scenario: Missing workspace exits with error
+- **WHEN** no `.dotagents/` directory exists in the current or any parent directory
+- **THEN** the command exits 1 with an error referencing `dotagents init`
+
+#### Scenario: --full shows complete descriptions and body content
+- **WHEN** user runs `dotagents skills ls --full`
+- **THEN** each skill's full description is shown, word-wrapped at terminal width, followed by the full markdown body content
+
+#### Scenario: --json outputs skills as JSON array
+- **WHEN** user runs `dotagents skills ls --json`
+- **THEN** stdout contains a JSON array of skill objects with name, frontmatter fields, and body content; stderr contains any log messages
+
+#### Scenario: --json with empty workspace outputs empty array
+- **WHEN** user runs `dotagents skills ls --json` with no skills present
+- **THEN** stdout contains `[]` and the command exits 0
+
+#### Scenario: Without --full, body content is omitted
+- **WHEN** user runs `dotagents skills ls` without `--full`
+- **THEN** only the skill name and frontmatter metadata (description, license, compatibility) are shown; body content is not displayed

--- a/openspec/changes/add-json-full-flags/tasks.md
+++ b/openspec/changes/add-json-full-flags/tasks.md
@@ -12,7 +12,7 @@
 - [ ] 2.4 Implement `--full` body content rendering for `skills ls` CLI mode (include body after frontmatter)
 - [ ] 2.5 Ensure `--json` output uses stdout only, all logs/warnings go to stderr
 - [ ] 2.6 Ensure `--full` without `--json` shows body in text output
-- [ ] 2.7 Define `--json --full` combined behavior: `--json` always includes body content via `to_value()`, so `--full` is effectively a no-op when `--json` is present
+- [ ] 2.7 Define `--json --full` combined behavior: `--json` alone outputs frontmatter fields only; when `--full` is also present, add a `content` key with the raw markdown body string
 
 ## 3. Unit tests
 

--- a/openspec/changes/add-json-full-flags/tasks.md
+++ b/openspec/changes/add-json-full-flags/tasks.md
@@ -1,0 +1,38 @@
+## 1. CLI flag additions
+
+- [ ] 1.1 Add `--json` flag to `CommandsLs` subcommand in `src/cli/commands.rs`
+- [ ] 1.2 Add `--json` flag to `SkillsLs` subcommand in `src/cli/skills.rs`
+- [ ] 1.3 Ensure `--full` flag behavior extends to include body content (flag already exists in both commands)
+
+## 2. Core implementation
+
+- [ ] 2.1 Implement `--json` output for `commands ls`: collect `to_value()` results, serialize as JSON array, output to stdout
+- [ ] 2.2 Implement `--json` output for `skills ls`: same pattern as commands
+- [ ] 2.3 Implement `--full` body content rendering for `commands ls` CLI mode (include body after frontmatter)
+- [ ] 2.4 Implement `--full` body content rendering for `skills ls` CLI mode (include body after frontmatter)
+- [ ] 2.5 Ensure `--json` output uses stdout only, all logs/warnings go to stderr
+- [ ] 2.6 Ensure `--full` without `--json` shows body in text output
+
+## 3. Unit tests
+
+- [ ] 3.1 Test `commands ls --json` produces valid JSON array with correct fields
+- [ ] 3.2 Test `skills ls --json` produces valid JSON array with correct fields
+- [ ] 3.3 Test `commands ls --full` includes body content in text output
+- [ ] 3.4 Test `skills ls --full` includes body content in text output
+- [ ] 3.5 Test `commands ls` without `--full` does NOT include body content
+- [ ] 3.6 Test `commands ls --json` with empty workspace outputs `[]`
+- [ ] 3.7 Test `commands ls --json | jq` parses correctly (verify pipeable)
+
+## 4. E2E tests
+
+- [ ] 4.1 Add e2e test: `dotagents commands ls --json` valid JSON with body content
+- [ ] 4.2 Add e2e test: `dotagents skills ls --json` valid JSON with body content
+- [ ] 4.3 Add e2e test: `dotagents commands ls --full` shows body content in text output
+- [ ] 4.4 Add e2e test: `dotagents commands ls --json --full` validates both flags together
+- [ ] 4.5 Add e2e test: `dotagents commands ls` (default) does NOT include body content
+- [ ] 4.6 Add e2e test: empty workspace `--json` outputs `[]`
+
+## 5. Verification
+
+- [ ] 5.1 Run `mise check` and fix any format/lint issues
+- [ ] 5.2 Run `mise tests` and fix any failures

--- a/openspec/changes/add-json-full-flags/tasks.md
+++ b/openspec/changes/add-json-full-flags/tasks.md
@@ -12,6 +12,7 @@
 - [ ] 2.4 Implement `--full` body content rendering for `skills ls` CLI mode (include body after frontmatter)
 - [ ] 2.5 Ensure `--json` output uses stdout only, all logs/warnings go to stderr
 - [ ] 2.6 Ensure `--full` without `--json` shows body in text output
+- [ ] 2.7 Define `--json --full` combined behavior: `--json` always includes body content via `to_value()`, so `--full` is effectively a no-op when `--json` is present
 
 ## 3. Unit tests
 

--- a/openspec/changes/add-providers-command/.openspec.yaml
+++ b/openspec/changes/add-providers-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/add-providers-command/design.md
+++ b/openspec/changes/add-providers-command/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The official registry at `public/v1/templates/registry.json` lists 24 providers with `path` and `checksums`. Users only see these through the init wizard multiselect. After init, there is no way to browse available providers — the registry is consumed silently by deploy.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a `dotagents providers ls` command to list registered providers
+- Extend registry entries with `name` (display label) and `url` (docs link) fields
+- Support CLI mode (plain list, `--url`, `--json`) and TUI mode (fuzzy-search browser)
+- Offline mode reads from template-source cache
+
+**Non-Goals:**
+- Adding/removing registries (this is a future concern)
+- Live editing of registry entries
+- Provider detail pages beyond name/url/slug
+
+## Decisions
+
+### Registry schema: additive extension with optional fields
+`ProviderEntry` gains `name: Option<String>` and `url: Option<String>`. This keeps backward compatibility — existing registries without these fields still parse correctly. The CI registry generation script reads `name` and `url` from each provider's `provider.toml` and writes them into `registry.json`.
+
+### Providers command is read-only
+No mutation of config, registry, or deployed files. This mirrors the read-only nature of `--json`/`--full` flags in #81. The command fetches the registry (or reads from cache) and displays it.
+
+### TUI fuzzy search via cliclack
+Cliclack's `Select` prompt with `filter` enabled provides fuzzy search out of the box. No new dependency needed. Each option shows `{name} [{slug}]` with optional URL on a second line when `--url` is active.
+
+### Offline mode reuses template-source cache
+In offline mode (`--offline`), the command reads `registry.json` from the template-source cache (the same cache used by deploy for provider resolution). If the cache is cold, it errors with instructions to run without `--offline` to populate it.
+
+### CLI output format consistency
+- Default: `slug  (name)` per line
+- `--url`: `slug  (name) — https://...`
+- `--json`: array of `{ "slug", "name", "url" }` objects
+
+## Risks / Trade-offs
+
+- **Registry changes need script updates**: The CI script must be updated to extract and write `name`/`url` from `provider.toml` files. → Keep fields optional so a missing `name`/`url` in `provider.toml` just omits them from registry output.
+- **Cache dependency**: Offline mode requires prior online fetch. → Error message clearly instructs user to run online first.

--- a/openspec/changes/add-providers-command/design.md
+++ b/openspec/changes/add-providers-command/design.md
@@ -21,7 +21,7 @@ The official registry at `public/v1/templates/registry.json` lists 24 providers 
 `ProviderEntry` gains `name: Option<String>` and `url: Option<String>`. This keeps backward compatibility — existing registries without these fields still parse correctly. The CI registry generation script reads `name` and `url` from each provider's `provider.toml` and writes them into `registry.json`.
 
 ### Providers command is read-only
-No mutation of config, registry, or deployed files. This mirrors the read-only nature of `--json`/`--full` flags in #81. The command fetches the registry (or reads from cache) and displays it.
+No mutation of config, registry, or deployed files. This mirrors the read-only nature of `--json`/`--full` flags established in the `add-json-full-flags` proposal. The command fetches the registry (or reads from cache) and displays it.
 
 ### TUI fuzzy search via cliclack
 Cliclack's `Select` prompt with `filter` enabled provides fuzzy search out of the box. No new dependency needed. Each option shows `{name} [{slug}]` with optional URL on a second line when `--url` is active.

--- a/openspec/changes/add-providers-command/proposal.md
+++ b/openspec/changes/add-providers-command/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Users currently have no way to browse the provider registry outside the init wizard. After init, the 24 registered providers are invisible — users can't discover new providers, look up documentation, or verify which providers are available without re-running init or digging into the registry JSON. A `providers` command gives users visibility into the ecosystem.
+
+## What Changes
+
+- Add a `dotagents providers ls` subcommand that lists all providers from the official registry
+- Extend `registry.json` entries with `name` (human-readable display label) and `url` (documentation link) fields — **additive, not breaking**
+- CLI mode: list provider slug + name per line; `--url` appends URLs; `--json` outputs structured JSON
+- TUI mode: interactive fuzzy-search browser showing provider details with clickable URLs
+- Offline mode: lists providers from the cached registry if available, errors if cold and `--offline` is set
+- Update the CI registry generation script to include `name` and `url` fields for each provider
+
+## Capabilities
+
+### New Capabilities
+- `providers-list`: listing and browsing registered AI agent providers from the official registry, with machine-readable JSON and interactive TUI modes
+
+### Modified Capabilities
+- `provider-registry-resolution`: registry entry schema extended with `name` and `url` fields — resolution logic unchanged, new fields are purely additive for display purposes
+
+## Impact
+
+- `src/schema/registry.rs` — `ProviderEntry` struct gains `name` and `url` fields
+- `src/cli/providers.rs` — new module implementing the `providers ls` subcommand
+- `src/cli/options.rs` — new `Action::Providers` variant with `ProvidersAction` enum
+- `public/v1/templates/registry.json` — each provider entry extended with `name` and `url`
+- `scripts/ci/generate_registry.sh` — updated to include `name`/`url` from `provider.toml`
+- `tests/e2e/` — new e2e tests for CLI and TUI paths

--- a/openspec/changes/add-providers-command/specs/provider-registry-resolution/spec.md
+++ b/openspec/changes/add-providers-command/specs/provider-registry-resolution/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Missing template or target is resolved from the official registry
+When a `FeatureSettings` block has `template = None` and/or `target = None`, `dotagents deploy` SHALL attempt to fill the missing fields by fetching `https://dotagents.soorya-u.dev/v1/templates/registry.json` and parsing the provider's `provider.toml`. Resolution is per-field: if only one field is absent, only that field is filled in. The resolved values are used in-memory only; `config.toml` is never written. The registry schema now includes optional `name` and `url` fields per provider entry; these SHALL be ignored by deploy resolution.
+
+#### Scenario: Both template and target missing — resolved from registry
+- **WHEN** a provider appears in `targets` with no `[providers.<name>.<feature>]` block configured
+- **THEN** deploy fetches `registry.json`, downloads the provider's `provider.toml`, extracts the feature's `template` URL and `target` path, and proceeds with rendering using those values. The `name` and `url` fields in the registry entry are ignored by deploy.
+
+#### Scenario: Only target missing — template taken from config, target from registry
+- **WHEN** `[providers.claude.commands]` has `template = "my-custom.hbs"` but no `target`
+- **THEN** deploy uses `my-custom.hbs` as the template and fills in `target` from the registry's `provider.toml` for the `claude` provider's `commands` feature
+
+#### Scenario: Both fields present — registry is not consulted
+- **WHEN** a provider's `FeatureSettings` has both `template` and `target` set
+- **THEN** `registry.json` is not fetched for that provider/feature; existing behaviour is unchanged
+
+## ADDED Requirements
+
+### Requirement: Registry entries MAY include name and url display fields
+Each provider entry in `registry.json` MAY include a `name` field (human-readable display label) and a `url` field (documentation hyperlink). Both fields SHALL be strings when present. Absence of these fields SHALL NOT cause parsing failures; the fields are purely additive for display purposes.
+
+#### Scenario: Registry entry with name and url parses successfully
+- **WHEN** `registry.json` contains `"gemini": { "path": "...", "checksums": {...}, "name": "Gemini CLI", "url": "https://google-gemini.github.io/cli" }`
+- **THEN** the `Registry` struct parses `name` as `Some("Gemini CLI")` and `url` as `Some("https://google-gemini.github.io/cli")`
+
+#### Scenario: Registry entry without name and url parses successfully
+- **WHEN** `registry.json` contains `"claude": { "path": "...", "checksums": {...} }` without `name` or `url` fields
+- **THEN** the `Registry` struct parses `name` as `None` and `url` as `None`
+
+#### Scenario: Deploy resolution ignores name and url fields
+- **WHEN** deploy resolves a provider's template/target from the registry and the entry has `name` and `url` fields
+- **THEN** deploy proceeds normally; the `name` and `url` fields have no effect on template resolution or rendering

--- a/openspec/changes/add-providers-command/specs/providers-list/spec.md
+++ b/openspec/changes/add-providers-command/specs/providers-list/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: providers ls lists all providers from the registry
+`dotagents providers ls` SHALL fetch the official registry, parse it, and display every provider as a list entry showing the provider slug and display name. Providers SHALL be listed in the order they appear in the registry. If the registry cannot be fetched and `--offline` is not set, the command SHALL fall back to the template-source cache.
+
+#### Scenario: Successful listing of all providers
+- **WHEN** `dotagents providers ls` is run and the registry is accessible
+- **THEN** each provider is displayed on its own line as `{slug}  ({name})` and the command exits 0
+
+#### Scenario: Empty registry handled gracefully
+- **WHEN** the registry is fetched but contains no provider entries
+- **THEN** a message indicating no providers were found is displayed and the command exits 0
+
+#### Scenario: Registry fetch failure falls back to cache
+- **WHEN** the registry cannot be fetched due to a network error and the template-source cache has a cached `registry.json`
+- **THEN** providers are listed from the cached registry, a warning is logged about the fetch failure, and the command exits 0
+
+#### Scenario: Registry unreachable and cache cold — hard error
+- **WHEN** the registry cannot be fetched and no cached `registry.json` exists
+- **THEN** the command exits 1 with an error indicating the registry is unavailable
+
+### Requirement: --url flag appends documentation URLs to provider listing
+When `--url` is passed to `dotagents providers ls`, each provider line SHALL include the documentation URL extracted from the registry entry's `url` field. Providers without a `url` field SHALL show "N/A" or be omitted in place of the URL.
+
+#### Scenario: Provider with URL shows the URL
+- **WHEN** `dotagents providers ls --url` is run and a provider has `url = "https://example.com/docs"`
+- **THEN** that provider's line reads `{slug}  ({name}) — https://example.com/docs`
+
+#### Scenario: Provider without URL shows placeholder
+- **WHEN** `dotagents providers ls --url` is run and a provider has no `url` field
+- **THEN** that provider's line reads `{slug}  ({name}) — N/A`
+
+### Requirement: --json flag outputs registry data as JSON
+When `--json` is passed to `dotagents providers ls`, the command SHALL output a JSON array of provider objects with `slug`, `name`, and `url` fields. The output SHALL be valid JSON on stdout. All log/warning output SHALL go to stderr.
+
+#### Scenario: JSON output matches registry data
+- **WHEN** `dotagents providers ls --json` is run
+- **THEN** stdout contains a JSON array like `[{"slug":"claude","name":"Claude Code","url":"https://..."}]` and the command exits 0
+
+#### Scenario: JSON output with empty registry
+- **WHEN** `dotagents providers ls --json` is run and the registry has no providers
+- **THEN** stdout contains `[]` and the command exits 0
+
+### Requirement: TUI mode provides interactive fuzzy-search browser
+When stdin is a TTY and `--json` is not passed, `dotagents providers ls` SHALL display an interactive fuzzy-search selection list using cliclack. Each option SHALL show the provider name with the slug in brackets. When `--url` is active, the URL SHALL be displayed inline. Selecting a provider and pressing Enter SHALL display its full details (slug, name, URL). Esc or Ctrl+C SHALL exit.
+
+#### Scenario: TUI shows all providers with fuzzy filter
+- **WHEN** `dotagents providers ls` is run in a TTY
+- **THEN** a cliclack select prompt is shown with all providers and a search filter that narrows results as the user types
+
+#### Scenario: TUI shows provider detail on selection
+- **WHEN** user selects a provider from the TUI list and presses Enter
+- **THEN** a detail view is shown with the provider's slug, name, and URL (if available)
+
+### Requirement: --offline flag reads registry from cache only
+When `--offline` is passed, `dotagents providers ls` SHALL NOT make any network request. It SHALL read `registry.json` from the template-source cache. If no cached registry exists, the command SHALL error with a clear message instructing the user to run without `--offline` first.
+
+#### Scenario: Offline mode with warm cache succeeds
+- **WHEN** `dotagents providers ls --offline` is run and the template-source cache has `registry.json`
+- **THEN** providers are listed from the cache and no network request is made
+
+#### Scenario: Offline mode with cold cache errors
+- **WHEN** `dotagents providers ls --offline` is run and no cached `registry.json` exists
+- **THEN** the command exits 1 with an error message directing the user to run without `--offline`
+
+### Requirement: providers ls is read-only
+`dotagents providers ls` SHALL NOT modify any files on disk — no config files, no cache files, no deployed output. It SHALL only read from disk and/or network.
+
+#### Scenario: No file writes occur
+- **WHEN** `dotagents providers ls` completes successfully
+- **THEN** no files in `.dotagents/`, workspace, or template-source cache are modified compared to before the command ran (excluding any log files)

--- a/openspec/changes/add-providers-command/specs/providers-list/spec.md
+++ b/openspec/changes/add-providers-command/specs/providers-list/spec.md
@@ -5,7 +5,7 @@
 
 #### Scenario: Successful listing of all providers
 - **WHEN** `dotagents providers ls` is run and the registry is accessible
-- **THEN** each provider is displayed on its own line as `{slug}  ({name})` and the command exits 0
+- **THEN** each provider is displayed on its own line as `{slug}  ({name})` (or just `{slug}` when `name` is absent) and the command exits 0
 
 #### Scenario: Empty registry handled gracefully
 - **WHEN** the registry is fetched but contains no provider entries
@@ -20,7 +20,7 @@
 - **THEN** the command exits 1 with an error indicating the registry is unavailable
 
 ### Requirement: --url flag appends documentation URLs to provider listing
-When `--url` is passed to `dotagents providers ls`, each provider line SHALL include the documentation URL extracted from the registry entry's `url` field. Providers without a `url` field SHALL show "N/A" or be omitted in place of the URL.
+When `--url` is passed to `dotagents providers ls`, each provider line SHALL include the documentation URL extracted from the registry entry's `url` field. Providers without a `url` field SHALL show "N/A" in place of the URL.
 
 #### Scenario: Provider with URL shows the URL
 - **WHEN** `dotagents providers ls --url` is run and a provider has `url = "https://example.com/docs"`
@@ -50,7 +50,7 @@ When stdin is a TTY and `--json` is not passed, `dotagents providers ls` SHALL d
 
 #### Scenario: TUI shows provider detail on selection
 - **WHEN** user selects a provider from the TUI list and presses Enter
-- **THEN** a detail view is shown with the provider's slug, name, and URL (if available)
+- **THEN** a detail view is shown with the provider's slug, name, and URL (if available). Pressing any key returns to the provider list; pressing Esc exits the command.
 
 ### Requirement: --offline flag reads registry from cache only
 When `--offline` is passed, `dotagents providers ls` SHALL NOT make any network request. It SHALL read `registry.json` from the template-source cache. If no cached registry exists, the command SHALL error with a clear message instructing the user to run without `--offline` first.

--- a/openspec/changes/add-providers-command/tasks.md
+++ b/openspec/changes/add-providers-command/tasks.md
@@ -1,0 +1,43 @@
+## 1. Registry schema extension
+
+- [ ] 1.1 Add `name: Option<String>` and `url: Option<String>` fields to `ProviderEntry` in `src/schema/registry.rs`
+- [ ] 1.2 Update `Registry` and `ProviderEntry` serde derives for new fields (optional = skip if absent)
+- [ ] 1.3 Add `name` and `url` to `public/v1/templates/registry.json` for each provider entry
+- [ ] 1.4 Add `name` and `url` fields to each provider's `public/v1/templates/<provider>/provider.toml`
+- [ ] 1.5 Update `scripts/ci/generate_registry.sh` to extract and include `name`/`url` from provider.toml
+
+## 2. CLI plumbing
+
+- [ ] 2.1 Add `Providers` variant to `Action` enum and `ProvidersAction` enum in `src/cli/options.rs`
+- [ ] 2.2 Create `src/cli/providers.rs` module with `handle` function
+- [ ] 2.3 Wire `Action::Providers` dispatch in `src/cli/runner.rs`
+- [ ] 2.4 Add `--url`, `--json`, `--offline` flags to the `providers ls` subcommand
+
+## 3. Core implementation
+
+- [ ] 3.1 Implement registry fetch/cache-read logic for providers command (reuse existing `Registry::fetch()` pattern)
+- [ ] 3.2 Implement CLI text output: default, `--url`, and `--json` modes
+- [ ] 3.3 Implement `--offline` mode with template-source cache fallback
+- [ ] 3.4 Implement TUI mode with cliclack fuzzy search (filtered Select)
+- [ ] 3.5 Implement TUI provider detail view on selection (slug, name, URL)
+
+## 4. Unit tests
+
+- [ ] 4.1 Test `ProviderEntry` deserialization with and without new `name`/`url` fields
+- [ ] 4.2 Test registry parsing with mixed entries (some with name/url, some without)
+- [ ] 4.3 Test CLI output formatting (default, `--url`, `--json`)
+- [ ] 4.4 Test offline mode cache-hit and cache-miss paths
+
+## 5. E2E tests
+
+- [ ] 5.1 tui-devtools discovery pass for `providers ls` TUI flow
+- [ ] 5.2 Add e2e test: `providers ls` CLI default output
+- [ ] 5.3 Add e2e test: `providers ls --url` output
+- [ ] 5.4 Add e2e test: `providers ls --json` valid JSON output
+- [ ] 5.5 Add e2e test: `providers ls --offline` with cold cache errors
+- [ ] 5.6 Add e2e test: `providers ls` TUI mode (fuzzy search and detail view)
+
+## 6. Verification
+
+- [ ] 6.1 Run `mise check` and fix any format/lint issues
+- [ ] 6.2 Run `mise tests` and fix any failures

--- a/openspec/changes/add-providers-command/tasks.md
+++ b/openspec/changes/add-providers-command/tasks.md
@@ -2,9 +2,8 @@
 
 - [ ] 1.1 Add `name: Option<String>` and `url: Option<String>` fields to `ProviderEntry` in `src/schema/registry.rs`
 - [ ] 1.2 Update `Registry` and `ProviderEntry` serde derives for new fields (optional = skip if absent)
-- [ ] 1.3 Add `name` and `url` to `public/v1/templates/registry.json` for each provider entry
-- [ ] 1.4 Add `name` and `url` fields to each provider's `public/v1/templates/<provider>/provider.toml`
-- [ ] 1.5 Update `scripts/ci/generate_registry.sh` to extract and include `name`/`url` from provider.toml
+- [ ] 1.3 Add `name` and `url` fields to each provider's `public/v1/templates/<provider>/provider.toml`
+- [ ] 1.4 Update `scripts/ci/generate_registry.sh` to extract and include `name`/`url` from provider.toml into the generated `registry.json`
 
 ## 2. CLI plumbing
 


### PR DESCRIPTION
## Summary

- **add-config-command**: Proposal for `dotagents config` subcommand with `app|global|local` targets, `--json` output, and `--edit` TUI mode
- **add-json-full-flags**: Proposal for `--json` and `--full` flags on `commands ls` and `skills ls` for machine-readable and verbose output
- **add-providers-command**: Proposal for `dotagents providers ls` subcommand with registry browsing, `--url`, `--json`, offline mode, and extended registry schema

## Testing

- Not run — this PR is spec-only (no implementation changes)
- Each change directory contains a tasks.md with verification steps to run when implemented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dotagents config` command to view and edit layered configuration (global, local, merged) with JSON output and interactive editor.
  * Added `--json` and `--full` flags to `commands ls` and `skills ls` for structured output and complete markdown content display.
  * Added `dotagents providers ls` command to browse the official provider registry with CLI, TUI, and offline modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->