### PR TITLE
Make local.config.toml optional + providers-ls spec

### DIFF
--- a/openspec/specs/provider-registry-resolution/spec.md
+++ b/openspec/specs/provider-registry-resolution/spec.md
@@ -1,9 +1,9 @@
 ### Requirement: Missing template or target is resolved from the official registry
-When a `FeatureSettings` block has `template = None` and/or `target = None`, `dotagents deploy` SHALL attempt to fill the missing fields by fetching `https://dotagents.soorya-u.dev/v1/templates/registry.json` and parsing the provider's `provider.toml`. Resolution is per-field: if only one field is absent, only that field is filled in. The resolved values are used in-memory only; `config.toml` is never written.
+When a `FeatureSettings` block has `template = None` and/or `target = None`, `dotagents deploy` SHALL attempt to fill the missing fields by fetching `https://dotagents.soorya-u.dev/v1/templates/registry.json` and parsing the provider's `provider.toml`. Resolution is per-field: if only one field is absent, only that field is filled in. The resolved values are used in-memory only; `config.toml` is never written. The registry schema now includes optional `name` and `url` fields per provider entry; these SHALL be ignored by deploy resolution.
 
 #### Scenario: Both template and target missing — resolved from registry
 - **WHEN** a provider appears in `targets` with no `[providers.<name>.<feature>]` block configured
-- **THEN** deploy fetches `registry.json`, downloads the provider's `provider.toml`, extracts the feature's `template` URL and `target` path, and proceeds with rendering using those values
+- **THEN** deploy fetches `registry.json`, downloads the provider's `provider.toml`, extracts the feature's `template` URL and `target` path, and proceeds with rendering using those values. The `name` and `url` fields in the registry entry are ignored by deploy.
 
 #### Scenario: Only target missing — template taken from config, target from registry
 - **WHEN** `[providers.claude.commands]` has `template = "my-custom.hbs"` but no `target`
@@ -55,3 +55,18 @@ When `dotagents deploy --offline` is specified, `dotagents deploy` SHALL NOT mak
 #### Scenario: Offline mode, cache cold — hard error
 - **WHEN** `--offline` is passed and no cached `provider.toml` exists for a provider that requires auto-resolution
 - **THEN** deploy stops with an error identifying the provider and instructing the user to run without `--offline` first to populate the cache
+
+### Requirement: Registry entries MAY include name and url display fields
+Each provider entry in `registry.json` MAY include a `name` field (human-readable display label) and a `url` field (documentation hyperlink). Both fields SHALL be strings when present. Absence of these fields SHALL NOT cause parsing failures; the fields are purely additive for display purposes.
+
+#### Scenario: Registry entry with name and url parses successfully
+- **WHEN** `registry.json` contains `"gemini": { "path": "...", "checksums": {...}, "name": "Gemini CLI", "url": "https://google-gemini.github.io/cli" }`
+- **THEN** the `Registry` struct parses `name` as `Some("Gemini CLI")` and `url` as `Some("https://google-gemini.github.io/cli")`
+
+#### Scenario: Registry entry without name and url parses successfully
+- **WHEN** `registry.json` contains `"claude": { "path": "...", "checksums": {...} }` without `name` or `url` fields
+- **THEN** the `Registry` struct parses `name` as `None` and `url` as `None`
+
+#### Scenario: Deploy resolution ignores name and url fields
+- **WHEN** deploy resolves a provider's template/target from the registry and the entry has `name` and `url` fields
+- **THEN** deploy proceeds normally; the `name` and `url` fields have no effect on template resolution or rendering

--- a/openspec/specs/providers-list/spec.md
+++ b/openspec/specs/providers-list/spec.md
@@ -1,0 +1,75 @@
+## Purpose
+
+Specifies the behaviour of `dotagents providers ls` — a read-only command that fetches the official provider registry and displays the available providers, with optional flags for URL display, JSON output, offline mode, and an interactive TUI browser.
+
+## Requirements
+
+### Requirement: providers ls lists all providers from the registry
+`dotagents providers ls` SHALL fetch the official registry, parse it, and display every provider as a list entry showing the provider slug and display name. Providers SHALL be listed in the order they appear in the registry. If the registry cannot be fetched and `--offline` is not set, the command SHALL fall back to the template-source cache.
+
+#### Scenario: Successful listing of all providers
+- **WHEN** `dotagents providers ls` is run and the registry is accessible
+- **THEN** each provider is displayed on its own line as `{slug}  ({name})` (or just `{slug}` when `name` is absent) and the command exits 0
+
+#### Scenario: Empty registry handled gracefully
+- **WHEN** the registry is fetched but contains no provider entries
+- **THEN** a message indicating no providers were found is displayed and the command exits 0
+
+#### Scenario: Registry fetch failure falls back to cache
+- **WHEN** the registry cannot be fetched due to a network error and the template-source cache has a cached `registry.json`
+- **THEN** providers are listed from the cached registry, a warning is logged about the fetch failure, and the command exits 0
+
+#### Scenario: Registry unreachable and cache cold — hard error
+- **WHEN** the registry cannot be fetched and no cached `registry.json` exists
+- **THEN** the command exits 1 with an error indicating the registry is unavailable
+
+### Requirement: --url flag appends documentation URLs to provider listing
+When `--url` is passed to `dotagents providers ls`, each provider line SHALL include the documentation URL extracted from the registry entry's `url` field. Providers without a `url` field SHALL show "N/A" in place of the URL.
+
+#### Scenario: Provider with URL shows the URL
+- **WHEN** `dotagents providers ls --url` is run and a provider has `url = "https://example.com/docs"`
+- **THEN** that provider's line reads `{slug}  ({name}) — https://example.com/docs`
+
+#### Scenario: Provider without URL shows placeholder
+- **WHEN** `dotagents providers ls --url` is run and a provider has no `url` field
+- **THEN** that provider's line reads `{slug}  ({name}) — N/A`
+
+### Requirement: --json flag outputs registry data as JSON
+When `--json` is passed to `dotagents providers ls`, the command SHALL output a JSON array of provider objects with `slug`, `name`, and `url` fields. The output SHALL be valid JSON on stdout. All log/warning output SHALL go to stderr.
+
+#### Scenario: JSON output matches registry data
+- **WHEN** `dotagents providers ls --json` is run
+- **THEN** stdout contains a JSON array like `[{"slug":"claude","name":"Claude Code","url":"https://..."}]` and the command exits 0
+
+#### Scenario: JSON output with empty registry
+- **WHEN** `dotagents providers ls --json` is run and the registry has no providers
+- **THEN** stdout contains `[]` and the command exits 0
+
+### Requirement: TUI mode provides interactive fuzzy-search browser
+When stdin is a TTY and `--json` is not passed, `dotagents providers ls` SHALL display an interactive fuzzy-search selection list using cliclack. Each option SHALL show the provider name with the slug in brackets. When `--url` is active, the URL SHALL be displayed inline. Selecting a provider and pressing Enter SHALL display its full details (slug, name, URL). Esc or Ctrl+C SHALL exit.
+
+#### Scenario: TUI shows all providers with fuzzy filter
+- **WHEN** `dotagents providers ls` is run in a TTY
+- **THEN** a cliclack select prompt is shown with all providers and a search filter that narrows results as the user types
+
+#### Scenario: TUI shows provider detail on selection
+- **WHEN** user selects a provider from the TUI list and presses Enter
+- **THEN** a detail view is shown with the provider's slug, name, and URL (if available). Pressing any key returns to the provider list; pressing Esc exits the command.
+
+### Requirement: --offline flag reads registry from cache only
+When `--offline` is passed, `dotagents providers ls` SHALL NOT make any network request. It SHALL read `registry.json` from the template-source cache. If no cached registry exists, the command SHALL error with a clear message instructing the user to run without `--offline` first.
+
+#### Scenario: Offline mode with warm cache succeeds
+- **WHEN** `dotagents providers ls --offline` is run and the template-source cache has `registry.json`
+- **THEN** providers are listed from the cache and no network request is made
+
+#### Scenario: Offline mode with cold cache errors
+- **WHEN** `dotagents providers ls --offline` is run and no cached `registry.json` exists
+- **THEN** the command exits 1 with an error message directing the user to run without `--offline`
+
+### Requirement: providers ls is read-only
+`dotagents providers ls` SHALL NOT modify any files on disk — no config files, no cache files, no deployed output. It SHALL only read from disk and/or network.
+
+#### Scenario: No file writes occur
+- **WHEN** `dotagents providers ls` completes successfully
+- **THEN** no files in `.dotagents/`, workspace, or template-source cache are modified compared to before the command ran (excluding any log files)

--- a/src/core/config/app.rs
+++ b/src/core/config/app.rs
@@ -11,6 +11,7 @@ use crate::core::config::{FeatureSettings, TomlConfig};
 use crate::core::features::Feature;
 use crate::templates::{RenderType, Templater};
 use crate::utils::merge::merge_optional;
+use crate::utils::path::get_application_dir;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -74,13 +75,22 @@ impl AppConfig {
     pub fn from_application(templater: &Templater) -> Result<Self> {
         let global_config_content =
             templater.render_template(RenderType::Name(GLOBAL_CONFIG_FILE.into()), None)?;
-        let local_config_content =
-            templater.render_template(RenderType::Name(LOCAL_CONFIG_FILE.into()), None)?;
 
-        let local_config = LocalConfig::from_toml(&local_config_content)?;
-        local_config.validate().context("invalid local config")?;
+        let local_config = {
+            let local_config_path = get_application_dir()?.join(LOCAL_CONFIG_FILE);
+            if local_config_path.exists() {
+                let content =
+                    templater.render_template(RenderType::Name(LOCAL_CONFIG_FILE.into()), None)?;
+                let config = LocalConfig::from_toml(&content)?;
+                config.validate().context("invalid local config")?;
+                config
+            } else {
+                LocalConfig::default()
+            }
+        };
+
         let global_config = GlobalConfig::from_toml(&global_config_content)?;
-        global_config.validate().context("invalid local config")?;
+        global_config.validate().context("invalid global config")?;
 
         let app_config = AppConfig::from((&global_config, &local_config));
 

--- a/src/templates/templater.rs
+++ b/src/templates/templater.rs
@@ -69,13 +69,18 @@ impl Templater {
             .join(GLOBAL_CONFIG_FILE)
             .to_string_lossy()
             .to_string();
-        let local_config_file = application_dir
-            .join(LOCAL_CONFIG_FILE)
-            .to_string_lossy()
-            .to_string();
+        let local_config_path = application_dir.join(LOCAL_CONFIG_FILE);
 
         self.register_template(GLOBAL_CONFIG_FILE, TemplateSource::File(global_config_file))?;
-        self.register_template(LOCAL_CONFIG_FILE, TemplateSource::File(local_config_file))?;
+
+        if local_config_path.exists() {
+            self.register_template(
+                LOCAL_CONFIG_FILE,
+                TemplateSource::File(local_config_path.to_string_lossy().to_string()),
+            )?;
+        } else {
+            self.register_template(LOCAL_CONFIG_FILE, TemplateSource::Text(String::new()))?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- `local.config.toml` is no longer required to exist — `AppConfig::from_application` falls back to `LocalConfig::default()` if the file is missing
- `Templater::register_config_templates` conditionally registers the local config template, using an empty string when the file is absent
- Updated provider-registry-resolution spec to allow optional `name` and `url` fields per registry entry; deploy resolution ignores them
- Added full spec for `dotagents providers ls` with TUI, `--json`, `--url`, and `--offline` flags

## Testing

- `cargo test` — all unit and integration tests pass
- Verified that `deploy` succeeds with only `config.toml` (no `local.config.toml`)
- Verified that `deploy` still merges overrides when `local.config.toml` exists
- Spec-only changes — no runtime test for providers-ls; code to follow
- Ran `mise check` (fmt + clippy) — clean