### PR TITLE
Enable deploy TUI test, add temp dir cleanup, update init tests

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -455,6 +455,12 @@ mod tests {
             dir: Some(target.clone()),
             template: Some(InitTemplate::Starter),
             force: true,
+            features: Some(vec![
+                Feature::Commands,
+                Feature::Instructions,
+                Feature::Mcp,
+                Feature::Skills,
+            ]),
             ..default_opts()
         };
         initialize_agents_dir(opts).expect("init should succeed");
@@ -474,6 +480,12 @@ mod tests {
             dir: Some(target.clone()),
             template: Some(InitTemplate::Starter),
             force: true,
+            features: Some(vec![
+                Feature::Commands,
+                Feature::Instructions,
+                Feature::Mcp,
+                Feature::Skills,
+            ]),
             ..default_opts()
         };
         initialize_agents_dir(opts).expect("init should succeed");

--- a/tests/e2e/commands.test.ts
+++ b/tests/e2e/commands.test.ts
@@ -637,6 +637,10 @@ test.describe("commands new TUI – T07 deploy on Yes", () => {
 			terminal.keyPress("Enter"); // Yes to deploy
 			await expect(terminal.getByText("Run in offline mode?")).toBeVisible();
 			terminal.keyPress("Enter"); // accept online
+			await expect(terminal.getByText("written")).toBeVisible();
+			expect(existsSync(join(d, ".mycode/commands/deploy-test-cmd.md"))).toBe(
+				true,
+			);
 		} finally {
 			cleanup(d);
 		}

--- a/tests/e2e/commands.test.ts
+++ b/tests/e2e/commands.test.ts
@@ -608,25 +608,24 @@ test.describe("commands new TUI – T06 interactive prompts", () => {
 // the terminal interaction flow too complex for reliable TUI testing. The
 // deploy functionality is covered by the deploy CLI tests (T15) and journey
 // tests (J07).
-test.describe("commands new TUI – T07 deploy on Yes (skipped)", () => {
-	// stub program — setup runs inside the (skipped) body so no filesystem
-	// mutations happen at describe evaluation time
-	test.use({ program: { file: "bash", args: ["-c", "true"] } });
+test.describe("commands new TUI – T07 deploy on Yes", () => {
+	const d = makeTmpDir();
+	run(["init", "--template", "with-custom-provider"], d);
+	const lcPath = join(d, ".dotagents/local.config.toml");
+	writeFileSync(
+		lcPath,
+		readFileSync(lcPath, "utf8").replace(
+			/targets\s*=\s*\["gemini"\]/,
+			"targets = []",
+		),
+	);
+	test.use({
+		program: shellProgram(d, ["commands", "new", "deploy-test-cmd"]),
+	});
 
-	test.skip("answering Yes to deploy prompt runs deploy (deploy prompt is nested inside add)", async ({
+	test("answering Yes to deploy prompt runs deploy (deploy prompt is nested inside add)", async ({
 		terminal,
 	}) => {
-		// setup deferred into body — never runs because test is skipped
-		const d = makeTmpDir();
-		run(["init", "--template", "with-custom-provider"], d);
-		const lcPath = join(d, ".dotagents/local.config.toml");
-		writeFileSync(
-			lcPath,
-			readFileSync(lcPath, "utf8").replace(
-				/targets\s*=\s*\["gemini"\]/,
-				"targets = []",
-			),
-		);
 		try {
 			await expect(terminal.getByText("Description")).toBeVisible();
 			terminal.write("Deploy test");

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -26,7 +26,11 @@ function ensureCleanupRegistered(): void {
 	// Synchronous cleanup for process exit events (async handlers are ignored).
 	process.on("exit", () => {
 		for (const dir of CLEANUP_DIRS) {
-			rmSync(dir, { recursive: true, force: true });
+			try {
+				rmSync(dir, { recursive: true, force: true });
+			} catch (err) {
+				process.stderr.write(`cleanup failed for ${dir}: ${err}\n`);
+			}
 		}
 	});
 }

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -13,14 +13,36 @@ import { join, resolve } from "node:path";
 /// Tests are run with cwd=tests/e2e; the binary sits two levels up at <repo>/target/release/.
 export const BIN = resolve(process.cwd(), "../../target/release/dotagents");
 
+/// Directories created by makeTmpDir that need cleanup when the worker process exits.
+/// tui-test runs each test file in an isolated worker; registering on process exit
+/// ensures cleanup runs even if afterAll hooks are lost during suite serialization.
+const CLEANUP_DIRS = new Set<string>();
+
+let cleanupRegistered = false;
+function ensureCleanupRegistered(): void {
+	if (cleanupRegistered) return;
+	cleanupRegistered = true;
+
+	// Synchronous cleanup for process exit events (async handlers are ignored).
+	process.on("exit", () => {
+		for (const dir of CLEANUP_DIRS) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+}
+
 /// Create a fresh isolated temp directory for a single test
 export function makeTmpDir(): string {
-	return mkdtempSync(join(tmpdir(), "dotagents-test-"));
+	ensureCleanupRegistered();
+	const dir = mkdtempSync(join(tmpdir(), "dotagents-test-"));
+	CLEANUP_DIRS.add(dir);
+	return dir;
 }
 
 /// Remove a temp directory created by makeTmpDir
 export function cleanup(dir: string): void {
 	rmSync(dir, { recursive: true, force: true });
+	CLEANUP_DIRS.delete(dir);
 }
 
 /// Run the binary with the given args in the given working directory (non-TTY).

--- a/tests/e2e/init.test.ts
+++ b/tests/e2e/init.test.ts
@@ -3,8 +3,6 @@ import { join } from "node:path";
 import { expect, Key, test } from "@microsoft/tui-test";
 import { cleanup, makeTmpDir, run, shellProgram } from "./helpers.js";
 
-// ── CLI flows (non-interactive) ──────────────────────────────────────────────
-
 test.describe("init CLI – file tree", () => {
 	// C01: starter template creates expected files
 	test("starter template creates core files", async () => {

--- a/tests/e2e/providers.test.ts
+++ b/tests/e2e/providers.test.ts
@@ -1,8 +1,6 @@
 import { expect, test } from "@microsoft/tui-test";
 import { cleanup, makeTmpDir, run, seedRegistryCache } from "./helpers.js";
 
-// ── providers ls – CLI ────────────────────────────────────────────────────────
-
 test.describe("providers ls CLI", () => {
 	// --json exits 0 and returns a valid JSON array with slug/name/url fields
 	test("--json exits 0 and returns valid JSON array", async () => {


### PR DESCRIPTION
## Summary

- Enable the previously skipped `commands new TUI – T07 deploy on Yes` e2e test with proper setup outside the test body
- Add automatic temp directory cleanup on worker process exit via a `Set`-based registry, ensuring cleanup runs even if `afterAll` hooks are lost
- Update `init` unit tests to explicitly pass all features (`Commands`, `Instructions`, `Mcp`, `Skills`) to `initialize_agents_dir`
- Remove stray comment separator lines in `init.test.ts` and `providers.test.ts`

## Testing

- E2e: `tests/e2e/commands.test.ts` T07 test now runs and validates deploy prompt flow after `commands new`
- Unit: `init` tests updated with explicit feature flags — `mise tests` passes
- N/A for temp dir cleanup (infrastructure change verified manually and via existing test suite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for interactive command deployment scenarios
  * Improved test environment setup and temporary directory cleanup handling

* **Chores**
  * Removed obsolete test section comments for cleaner test organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soorya-u/dotagents/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->