### PR TITLE
Show cancel message when user declines undeploy confirmation in TUI

### DIFF
--- a/src/cli/undeploy.rs
+++ b/src/cli/undeploy.rs
@@ -81,6 +81,9 @@ pub(super) fn undeploy(mut opts: UndeployOptions) -> Result<()> {
 
     // Interactive confirmation (skipped when --force or non-TTY).
     if !opts.force && !prompt_confirm_undeploy(entries.len()) {
+        if is_tui_enabled() {
+            cliclack::outro_cancel("Undeploy cancelled.").ok();
+        }
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- Adds an `outro_cancel("Undeploy cancelled.")` message in the TUI when the user declines the interactive undeploy confirmation prompt
- Message only displays when TUI is enabled and `--force` is not passed

## Testing

- Verified `cargo build` compiles successfully
- Verified `mise check` (fmt + clippy) passes
- `cargo test` suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Undeploy now displays a cancel feedback message when declining interactive confirmation (without `--force` flag), providing improved user feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soorya-u/dotagents/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->