### PR TITLE
Write `ls` output to stdout in non-TUI mode

### DIFF
--- a/src/cli/ui/common.rs
+++ b/src/cli/ui/common.rs
@@ -1,14 +1,24 @@
 use console::style;
 use crossterm::terminal;
 
-/// Apply cyan+bold styling to a name for regular list rows.
+use crate::utils::tui::is_tui_enabled;
+
+/// Apply cyan+bold styling to a name for regular list rows, or plain text in CI mode.
 pub(crate) fn styled_name(name: &str) -> String {
-    style(name).cyan().bold().to_string()
+    if is_tui_enabled() {
+        style(name).cyan().bold().to_string()
+    } else {
+        name.to_string()
+    }
 }
 
-/// Apply green+bold styling to a name for note headers (used with --content in TTY).
+/// Apply green+bold styling to a name for note headers, or plain text in CI mode.
 pub(crate) fn styled_note_name(name: &str) -> String {
-    style(name).green().bold().to_string()
+    if is_tui_enabled() {
+        style(name).green().bold().to_string()
+    } else {
+        name.to_string()
+    }
 }
 
 /// Detect terminal column count, falling back to 80 on error.

--- a/src/cli/ui/ls.rs
+++ b/src/cli/ui/ls.rs
@@ -7,7 +7,7 @@ use crate::prelude::*;
 use crate::schema::list_item::ListItem;
 use crate::utils::tui::is_tui_enabled;
 
-/// Render one section of items with cliclack log output.
+/// Render one section of items with cliclack log output in TUI mode, or plain println in CI mode.
 fn render_section(items: &[ListItem], content: bool, name_col: usize, cols: usize) {
     for item in items {
         if content && is_tui_enabled() {
@@ -30,7 +30,13 @@ fn render_section(items: &[ListItem], content: bool, name_col: usize, cols: usiz
             };
 
             let padded = format!("{:<width$}", item.name, width = name_col);
-            info!("{} — {}", styled_name(&padded), desc);
+            let line = format!("{} — {}", styled_name(&padded), desc);
+
+            if is_tui_enabled() {
+                info!("{}", line);
+            } else {
+                println!("{}", line);
+            }
 
             if content
                 && let Some(body) = &item.body
@@ -41,7 +47,11 @@ fn render_section(items: &[ListItem], content: bool, name_col: usize, cols: usiz
                 for line in body.lines() {
                     let wrapped = wrap_at_width(line, body_avail.max(10), " ");
                     for sub_line in wrapped.lines() {
-                        info!("{}{}", body_indent, sub_line);
+                        if is_tui_enabled() {
+                            info!("{}{}", body_indent, sub_line);
+                        } else {
+                            println!("{}{}", body_indent, sub_line);
+                        }
                     }
                 }
             }
@@ -52,7 +62,11 @@ fn render_section(items: &[ListItem], content: bool, name_col: usize, cols: usiz
 /// Render the commands listing for `dotagents commands ls`.
 pub(crate) fn render_commands(items: Vec<ListItem>, content: bool) {
     if items.is_empty() {
-        info!("No commands found.");
+        if is_tui_enabled() {
+            info!("No commands found.");
+        } else {
+            println!("No commands found.");
+        }
         outro("").ok();
         return;
     }
@@ -67,7 +81,11 @@ pub(crate) fn render_commands(items: Vec<ListItem>, content: bool) {
 /// Render the skills listing for `dotagents skills ls`.
 pub(crate) fn render_skills(items: Vec<ListItem>, content: bool) {
     if items.is_empty() {
-        info!("No skills found.");
+        if is_tui_enabled() {
+            info!("No skills found.");
+        } else {
+            println!("No skills found.");
+        }
         outro("").ok();
         return;
     }

--- a/tests/e2e/commands.test.ts
+++ b/tests/e2e/commands.test.ts
@@ -184,9 +184,9 @@ test.describe("commands ls CLI", () => {
 				],
 				d,
 			);
-			const { exitCode, stderr } = run(["commands", "ls"], d);
+			const { exitCode, stdout } = run(["commands", "ls"], d);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/hello/);
+			expect(stdout).toMatch(/hello/);
 		} finally {
 			cleanup(d);
 		}
@@ -326,9 +326,9 @@ test.describe("commands ls CLI", () => {
 				],
 				d,
 			);
-			const { exitCode, stderr } = run(["commands", "ls", "--content"], d);
+			const { exitCode, stdout } = run(["commands", "ls", "--content"], d);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/var\.agent_name/);
+			expect(stdout).toMatch(/var\.agent_name/);
 		} finally {
 			cleanup(d);
 		}
@@ -348,9 +348,9 @@ test.describe("commands ls CLI", () => {
 				],
 				d,
 			);
-			const { exitCode, stderr } = run(["commands", "ls"], d);
+			const { exitCode, stdout } = run(["commands", "ls"], d);
 			expect(exitCode).toBe(0);
-			expect(stderr).not.toMatch(/var\.agent_name/);
+			expect(stdout).not.toMatch(/var\.agent_name/);
 		} finally {
 			cleanup(d);
 		}
@@ -418,13 +418,13 @@ test.describe("commands ls CLI", () => {
 				d,
 			);
 			run(["commands", "new", "greet", "--description", "test"], d);
-			const { exitCode, stderr } = run(
+			const { exitCode, stdout } = run(
 				["commands", "ls", "--command", "greet"],
 				d,
 			);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/greet/);
-			expect(stderr).not.toMatch(/hello/);
+			expect(stdout).toMatch(/greet/);
+			expect(stdout).not.toMatch(/hello/);
 		} finally {
 			cleanup(d);
 		}
@@ -444,12 +444,12 @@ test.describe("commands ls CLI", () => {
 				],
 				d,
 			);
-			const { exitCode, stderr } = run(
+			const { exitCode, stdout } = run(
 				["commands", "ls", "--command", "nonexistent"],
 				d,
 			);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/No commands found/);
+			expect(stdout).toMatch(/No commands found/);
 		} finally {
 			cleanup(d);
 		}
@@ -659,12 +659,12 @@ test.describe("commands --cwd", () => {
 				workspace,
 			);
 			run(["commands", "new", "greet", "--description", "Greet"], workspace);
-			const { exitCode, stderr } = run(
+			const { exitCode, stdout } = run(
 				["commands", "ls", "--cwd", workspace],
 				cwd,
 			);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/greet/);
+			expect(stdout).toMatch(/greet/);
 		} finally {
 			cleanup(cwd);
 			cleanup(workspace);
@@ -767,9 +767,9 @@ test.describe("commands --cwd", () => {
 				"--features",
 				"commands,instructions,mcp,skills",
 			]);
-			const { exitCode, stderr } = run(["commands", "ls", "--cwd", "sub"], d);
+			const { exitCode, stdout } = run(["commands", "ls", "--cwd", "sub"], d);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/hello/);
+			expect(stdout).toMatch(/hello/);
 		} finally {
 			cleanup(d);
 		}
@@ -790,9 +790,9 @@ test.describe("commands --cwd", () => {
 				d,
 			);
 			run(["commands", "new", "greet", "--description", "Test"], d);
-			const { exitCode, stderr } = run(["commands", "ls"], d);
+			const { exitCode, stdout } = run(["commands", "ls"], d);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/greet/);
+			expect(stdout).toMatch(/greet/);
 		} finally {
 			cleanup(d);
 		}

--- a/tests/e2e/skills.test.ts
+++ b/tests/e2e/skills.test.ts
@@ -185,9 +185,9 @@ test.describe("skills ls CLI", () => {
 				],
 				d,
 			);
-			const { exitCode, stderr } = run(["skills", "ls"], d);
+			const { exitCode, stdout } = run(["skills", "ls"], d);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/hello-skill/);
+			expect(stdout).toMatch(/hello-skill/);
 		} finally {
 			cleanup(d);
 		}
@@ -327,9 +327,9 @@ test.describe("skills ls CLI", () => {
 				],
 				d,
 			);
-			const { exitCode, stderr } = run(["skills", "ls", "--content"], d);
+			const { exitCode, stdout } = run(["skills", "ls", "--content"], d);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/var\.agent_name/);
+			expect(stdout).toMatch(/var\.agent_name/);
 		} finally {
 			cleanup(d);
 		}
@@ -349,9 +349,9 @@ test.describe("skills ls CLI", () => {
 				],
 				d,
 			);
-			const { exitCode, stderr } = run(["skills", "ls"], d);
+			const { exitCode, stdout } = run(["skills", "ls"], d);
 			expect(exitCode).toBe(0);
-			expect(stderr).not.toMatch(/var\.agent_name/);
+			expect(stdout).not.toMatch(/var\.agent_name/);
 		} finally {
 			cleanup(d);
 		}
@@ -394,12 +394,12 @@ test.describe("skills ls CLI", () => {
 				],
 				d,
 			);
-			const { exitCode, stderr } = run(
+			const { exitCode, stdout } = run(
 				["skills", "ls", "--skill", "hello-skill"],
 				d,
 			);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/hello-skill/);
+			expect(stdout).toMatch(/hello-skill/);
 		} finally {
 			cleanup(d);
 		}
@@ -419,12 +419,12 @@ test.describe("skills ls CLI", () => {
 				],
 				d,
 			);
-			const { exitCode, stderr } = run(
+			const { exitCode, stdout } = run(
 				["skills", "ls", "--skill", "nonexistent"],
 				d,
 			);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/No skills found/);
+			expect(stdout).toMatch(/No skills found/);
 		} finally {
 			cleanup(d);
 		}
@@ -674,12 +674,12 @@ test.describe("skills --cwd", () => {
 				workspace,
 			);
 			run(["skills", "new", "my-skill", "--description", "A skill"], workspace);
-			const { exitCode, stderr } = run(
+			const { exitCode, stdout } = run(
 				["skills", "ls", "--cwd", workspace],
 				cwd,
 			);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/my-skill/);
+			expect(stdout).toMatch(/my-skill/);
 		} finally {
 			cleanup(cwd);
 			cleanup(workspace);

--- a/tests/e2e/workflow.test.ts
+++ b/tests/e2e/workflow.test.ts
@@ -79,16 +79,16 @@ test.describe("J03-J04: CRUD – add, list, remove", () => {
 			run(["commands", "new", "greet", "--description", "test"], d);
 
 			// ls shows the new command
-			const { stderr } = run(["commands", "ls"], d);
-			expect(stderr).toMatch(/greet/);
+			const { stdout } = run(["commands", "ls"], d);
+			expect(stdout).toMatch(/greet/);
 
 			// rm it
 			run(["commands", "rm", "greet", "--force"], d);
 			expect(existsSync(join(d, ".dotagents/commands/greet.md"))).toBe(false);
 
 			// ls no longer shows greet as a command name (hello's description contains "greet" so use stricter pattern)
-			const { stderr: afterStderr } = run(["commands", "ls"], d);
-			expect(afterStderr).not.toMatch(/^\[.*INFO.*\]\s+greet\s/m);
+			const { stdout: afterStdout } = run(["commands", "ls"], d);
+			expect(afterStdout).not.toMatch(/^greet\s/m);
 		} finally {
 			cleanup(d);
 		}
@@ -234,19 +234,19 @@ test.describe("J08: full CRUD both types", () => {
 			run(["skills", "rm", "my-skill", "--force"], d);
 
 			// commands ls and skills ls both show empty
-			const { exitCode: cmdExit, stderr: cmdStderr } = run(
+			const { exitCode: cmdExit, stdout: cmdStdout } = run(
 				["commands", "ls"],
 				d,
 			);
 			expect(cmdExit).toBe(0);
-			expect(cmdStderr).toMatch(/No commands found/);
+			expect(cmdStdout).toMatch(/No commands found/);
 
-			const { exitCode: skillExit, stderr: skillStderr } = run(
+			const { exitCode: skillExit, stdout: skillStdout } = run(
 				["skills", "ls"],
 				d,
 			);
 			expect(skillExit).toBe(0);
-			expect(skillStderr).toMatch(/No skills found/);
+			expect(skillStdout).toMatch(/No skills found/);
 		} finally {
 			cleanup(d);
 		}


### PR DESCRIPTION
## Summary

- `commands ls` and `skills ls` now use `println!` instead of `info!` when TUI is not enabled (CI/non-interactive mode), routing output to stdout rather than stderr.
- `styled_name` and `styled_note_name` helpers skip ANSI styling in non-TUI mode, producing plain text output suitable for piping and CI logs.
- Updated e2e tests (`commands.test.ts`, `skills.test.ts`, `workflow.test.ts`) to assert on `stdout` instead of `stderr` for `ls` subcommands.

## Testing

- `mise tests:e2e` passes with all `ls` assertions now checking `stdout`.
- Verified `commands ls` and `skills ls` produce plain text on stdout when run without a TTY.
- Verified styled output is stripped (no ANSI codes) in non-TUI mode.
- Verified `--content`, `--command`/`--skill` filters, and `--cwd` flag all work correctly with stdout output.