### PR TITLE
Add `--deploy` flag to command/skill subcommands, remove `--no-gitignore` from undeploy

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -32,12 +32,12 @@ fn collect_field(value: Option<String>, prompt: &str, placeholder: &str) -> Resu
     Ok(String::new())
 }
 
-/// Deploy after command mutation: skip if --no-deploy, auto-deploy in CI, prompt in TTY.
-fn maybe_prompt_deploy(no_deploy: bool) -> Result<()> {
+/// Deploy after command mutation: skip if --no-deploy, auto-deploy if --deploy, auto-deploy in CI, prompt in TTY.
+fn maybe_prompt_deploy(force_deploy: bool, no_deploy: bool) -> Result<()> {
     if no_deploy {
         return Ok(());
     }
-    if !is_tui_enabled() {
+    if force_deploy || !is_tui_enabled() {
         deploy(DeployOptions::default()).context("deploy failed")?;
         return Ok(());
     }
@@ -96,7 +96,7 @@ pub(crate) fn new_command(opts: AddCommandOptions) -> Result<bool> {
 
     success!("Created {}", target.display());
 
-    maybe_prompt_deploy(opts.no_deploy)?;
+    maybe_prompt_deploy(opts.deploy, opts.no_deploy)?;
 
     if use_interactive {
         outro("").ok();
@@ -174,7 +174,7 @@ pub(crate) fn rm_command(opts: RmCommandOptions) -> Result<bool> {
         }
     }
 
-    maybe_prompt_deploy(opts.no_deploy)?;
+    maybe_prompt_deploy(opts.deploy, opts.no_deploy)?;
 
     outro("").ok();
     Ok(true)
@@ -369,14 +369,14 @@ mod tests {
         assert_eq!(result[0], serde_json::Value::String("not-an-object".into()));
     }
 
-    // maybe_prompt_deploy(true) skips deploy and returns immediately
+    // maybe_prompt_deploy(false, true) skips deploy and returns immediately
     #[test]
     fn maybe_prompt_deploy_no_deploy_true_skips_deploy() {
         // no_deploy=true causes early return without calling deploy
-        assert!(maybe_prompt_deploy(true).is_ok());
+        assert!(maybe_prompt_deploy(false, true).is_ok());
     }
 
-    // maybe_prompt_deploy(false) in CI auto-deploys without prompting
+    // maybe_prompt_deploy(false, false) in CI auto-deploys without prompting
     #[test]
     fn maybe_prompt_deploy_ci_calls_deploy_when_no_deploy_false() {
         use crate::utils::path::override_workspace_dir;
@@ -390,7 +390,7 @@ mod tests {
         override_workspace_dir(tmp.path().to_path_buf())
             .expect("commands deploy test should be able to set workspace lock");
         set_ci_mode(true);
-        let result = maybe_prompt_deploy(false);
+        let result = maybe_prompt_deploy(false, false);
         set_ci_mode(false);
         std::env::set_current_dir(&original_dir).unwrap();
         // Deploy succeeds trivially (no targets, no features), proving deploy was called

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -185,7 +185,7 @@ pub(crate) struct DeployOptions {
     pub no_cache: bool,
 
     /// Always update .gitignore without prompting.
-    #[clap(long)]
+    #[clap(long, conflicts_with = "no_gitignore")]
     pub gitignore: bool,
 
     /// Never update .gitignore.
@@ -276,6 +276,10 @@ pub(crate) struct AddCommandOptions {
     #[clap(long, short = 'f')]
     pub force: bool,
 
+    /// Deploy automatically after creating the command.
+    #[clap(long, conflicts_with = "no_deploy")]
+    pub deploy: bool,
+
     /// Skip automatic deploy after creating the command.
     #[clap(long, default_value_t = false)]
     pub no_deploy: bool,
@@ -305,6 +309,10 @@ pub(crate) struct AddSkillOptions {
     #[clap(long, short = 'f')]
     pub force: bool,
 
+    /// Deploy automatically after creating the skill.
+    #[clap(long, conflicts_with = "no_deploy")]
+    pub deploy: bool,
+
     /// Skip automatic deploy after creating the skill.
     #[clap(long, default_value_t = false)]
     pub no_deploy: bool,
@@ -321,6 +329,10 @@ pub(crate) struct RmCommandOptions {
     /// Skip the confirmation prompt.
     #[clap(long, short = 'f')]
     pub force: bool,
+
+    /// Deploy automatically after removing the command.
+    #[clap(long, conflicts_with = "no_deploy")]
+    pub deploy: bool,
 
     /// Skip automatic deploy after removing the command.
     #[clap(long, default_value_t = false)]
@@ -339,6 +351,10 @@ pub(crate) struct RmSkillOptions {
     #[clap(long, short = 'f')]
     pub force: bool,
 
+    /// Deploy automatically after removing the skill.
+    #[clap(long, conflicts_with = "no_deploy")]
+    pub deploy: bool,
+
     /// Skip automatic deploy after removing the skill.
     #[clap(long, default_value_t = false)]
     pub no_deploy: bool,
@@ -354,10 +370,6 @@ pub(crate) struct UndeployOptions {
     /// Skip confirmation prompt and delete user-edited files without asking.
     #[clap(long, short)]
     pub force: bool,
-
-    /// Do not remove entries from .gitignore.
-    #[clap(long)]
-    pub no_gitignore: bool,
 
     /// Preview what would be undeployed without deleting any files, clearing cache, or touching .gitignore.
     #[clap(long)]

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -37,12 +37,12 @@ fn collect_field(value: Option<String>, prompt: &str, placeholder: &str) -> Resu
     Ok(String::new())
 }
 
-/// Deploy after skill mutation: skip if --no-deploy, auto-deploy in CI, prompt in TTY.
-fn maybe_prompt_deploy(no_deploy: bool) -> Result<()> {
+/// Deploy after skill mutation: skip if --no-deploy, auto-deploy if --deploy, auto-deploy in CI, prompt in TTY.
+fn maybe_prompt_deploy(force_deploy: bool, no_deploy: bool) -> Result<()> {
     if no_deploy {
         return Ok(());
     }
-    if !is_tui_enabled() {
+    if force_deploy || !is_tui_enabled() {
         deploy(DeployOptions::default()).context("deploy failed")?;
         return Ok(());
     }
@@ -155,7 +155,7 @@ pub(crate) fn new_skill(opts: AddSkillOptions) -> Result<bool> {
 
     success!("Created {}", target.display());
 
-    maybe_prompt_deploy(opts.no_deploy)?;
+    maybe_prompt_deploy(opts.deploy, opts.no_deploy)?;
 
     if use_interactive {
         outro("").ok();
@@ -235,7 +235,7 @@ pub(crate) fn rm_skill(opts: RmSkillOptions) -> Result<bool> {
         }
     }
 
-    maybe_prompt_deploy(opts.no_deploy)?;
+    maybe_prompt_deploy(opts.deploy, opts.no_deploy)?;
 
     outro("").ok();
     Ok(true)
@@ -415,14 +415,14 @@ mod tests {
         assert_eq!(result[0]["content"], "body text");
     }
 
-    // maybe_prompt_deploy(true) skips deploy and returns immediately
+    // maybe_prompt_deploy(false, true) skips deploy and returns immediately
     #[test]
     fn maybe_prompt_deploy_no_deploy_true_skips_deploy() {
         // no_deploy=true causes early return without calling deploy
-        assert!(maybe_prompt_deploy(true).is_ok());
+        assert!(maybe_prompt_deploy(false, true).is_ok());
     }
 
-    // maybe_prompt_deploy(false) in CI auto-deploys without prompting
+    // maybe_prompt_deploy(false, false) in CI auto-deploys without prompting
     #[test]
     fn maybe_prompt_deploy_ci_calls_deploy_when_no_deploy_false() {
         use crate::utils::path::override_workspace_dir;
@@ -439,7 +439,7 @@ mod tests {
             return;
         }
         set_ci_mode(true);
-        let result = maybe_prompt_deploy(false);
+        let result = maybe_prompt_deploy(false, false);
         set_ci_mode(false);
         std::env::set_current_dir(&original_dir).unwrap();
         // Deploy succeeds trivially (no targets, no features), proving deploy was called

--- a/src/cli/undeploy.rs
+++ b/src/cli/undeploy.rs
@@ -36,9 +36,7 @@ pub(super) fn undeploy(mut opts: UndeployOptions) -> Result<()> {
         .collect();
 
     if entries.is_empty() {
-        if !opts.no_gitignore
-            && let Err(e) = clear_gitignore_fence(&workspace_root)
-        {
+        if let Err(e) = clear_gitignore_fence(&workspace_root) {
             warn!("Failed to update .gitignore: {}", e);
         }
         if opts.dry_run {
@@ -123,9 +121,7 @@ pub(super) fn undeploy(mut opts: UndeployOptions) -> Result<()> {
         .context("unable to save cache after undeploy")?;
 
     // Remove the dotagents-managed fence from .gitignore.
-    if !opts.no_gitignore
-        && let Err(e) = clear_gitignore_fence(&workspace_root)
-    {
+    if let Err(e) = clear_gitignore_fence(&workspace_root) {
         warn!("Failed to update .gitignore: {}", e);
     }
 

--- a/tests/e2e/undeploy.test.ts
+++ b/tests/e2e/undeploy.test.ts
@@ -21,7 +21,7 @@ test.describe("undeploy CLI – basic lifecycle", () => {
 			expect(existsSync(join(d, ".mycode/instructions.md"))).toBe(true);
 			expect(existsSync(join(d, ".mycode/commands/hello.md"))).toBe(true);
 
-			const { exitCode } = run(["undeploy", "--no-gitignore"], d);
+			const { exitCode } = run(["undeploy"], d);
 			expect(exitCode).toBe(0);
 			expect(existsSync(join(d, ".mycode/instructions.md"))).toBe(false);
 			expect(existsSync(join(d, ".mycode/commands/hello.md"))).toBe(false);
@@ -36,7 +36,7 @@ test.describe("undeploy CLI – basic lifecycle", () => {
 		try {
 			initWithLocalProvider(d);
 			run(["deploy", "--offline", "--no-gitignore"], d);
-			run(["undeploy", "--no-gitignore"], d);
+			run(["undeploy"], d);
 
 			const cachePath = join(d, ".dotagents/cache.toml");
 			if (existsSync(cachePath)) {
@@ -54,7 +54,7 @@ test.describe("undeploy CLI – basic lifecycle", () => {
 		try {
 			initWithLocalProvider(d);
 			// No deploy run — cache.toml does not exist
-			const { exitCode } = run(["undeploy", "--no-gitignore"], d);
+			const { exitCode } = run(["undeploy"], d);
 			expect(exitCode).toBe(0);
 		} finally {
 			cleanup(d);
@@ -67,8 +67,8 @@ test.describe("undeploy CLI – basic lifecycle", () => {
 		try {
 			initWithLocalProvider(d);
 			run(["deploy", "--offline", "--no-gitignore"], d);
-			run(["undeploy", "--no-gitignore"], d);
-			const { exitCode } = run(["undeploy", "--no-gitignore"], d);
+			run(["undeploy"], d);
+			const { exitCode } = run(["undeploy"], d);
 			expect(exitCode).toBe(0);
 		} finally {
 			cleanup(d);
@@ -77,26 +77,7 @@ test.describe("undeploy CLI – basic lifecycle", () => {
 });
 
 test.describe("undeploy CLI – gitignore handling", () => {
-	// U05: --no-gitignore preserves the managed fence after undeploy
-	test("--no-gitignore preserves .gitignore fence", async () => {
-		const d = makeTmpDir();
-		try {
-			initWithLocalProvider(d);
-			run(["deploy", "--offline", "--gitignore"], d);
-
-			const giBefore = readFileSync(join(d, ".gitignore"), "utf8");
-			expect(giBefore).toContain("region dotagents");
-
-			run(["undeploy", "--no-gitignore"], d);
-
-			const giAfter = readFileSync(join(d, ".gitignore"), "utf8");
-			expect(giAfter).toContain("region dotagents");
-		} finally {
-			cleanup(d);
-		}
-	});
-
-	// U06: default undeploy removes the managed fence from .gitignore
+	// U05: default undeploy removes the managed fence from .gitignore
 	test("undeploy removes .gitignore fence by default", async () => {
 		const d = makeTmpDir();
 		try {
@@ -125,7 +106,7 @@ test.describe("undeploy CLI – --no-cache integration", () => {
 			run(["deploy", "--no-cache", "--offline", "--no-gitignore"], d);
 			expect(existsSync(join(d, ".mycode/instructions.md"))).toBe(true);
 
-			const { exitCode } = run(["undeploy", "--no-gitignore"], d);
+			const { exitCode } = run(["undeploy"], d);
 			expect(exitCode).toBe(0);
 			expect(existsSync(join(d, ".mycode/instructions.md"))).toBe(false);
 		} finally {
@@ -164,7 +145,7 @@ test.describe("undeploy CLI – user-edited files", () => {
 				"User has manually edited this file.",
 			);
 
-			run(["undeploy", "--no-gitignore"], d);
+			run(["undeploy"], d);
 
 			// Hash mismatch + non-TTY → file skipped, still present
 			expect(existsSync(join(d, ".mycode/instructions.md"))).toBe(true);
@@ -185,7 +166,7 @@ test.describe("undeploy CLI – user-edited files", () => {
 				"User has manually edited this file.",
 			);
 
-			const { exitCode } = run(["undeploy", "--no-gitignore", "--force"], d);
+			const { exitCode } = run(["undeploy", "--force"], d);
 			expect(exitCode).toBe(0);
 			expect(existsSync(join(d, ".mycode/instructions.md"))).toBe(false);
 		} finally {
@@ -203,7 +184,7 @@ test.describe("undeploy CLI – empty dir pruning", () => {
 			run(["deploy", "--offline", "--no-gitignore"], d);
 			expect(existsSync(join(d, ".mycode/commands"))).toBe(true);
 
-			run(["undeploy", "--no-gitignore", "--force"], d);
+			run(["undeploy", "--force"], d);
 
 			expect(existsSync(join(d, ".mycode/commands"))).toBe(false);
 		} finally {
@@ -238,7 +219,7 @@ test.describe("undeploy TUI – T-U1 confirm Yes removes files", () => {
 	const d = makeTmpDir();
 	initWithLocalProvider(d);
 	run(["deploy", "--offline", "--no-gitignore"], d);
-	test.use({ program: shellProgram(d, ["undeploy", "--no-gitignore"]) });
+	test.use({ program: shellProgram(d, ["undeploy"]) });
 
 	test("selecting Yes on confirmation prompt removes deployed files", async ({
 		terminal,
@@ -262,7 +243,7 @@ test.describe("undeploy TUI – T-U2 confirm No aborts", () => {
 	const d = makeTmpDir();
 	initWithLocalProvider(d);
 	run(["deploy", "--offline", "--no-gitignore"], d);
-	test.use({ program: shellProgram(d, ["undeploy", "--no-gitignore"]) });
+	test.use({ program: shellProgram(d, ["undeploy"]) });
 
 	test("pressing Enter on default No aborts undeploy", async ({ terminal }) => {
 		try {
@@ -291,10 +272,7 @@ test.describe("undeploy CLI – PATH argument", () => {
 			run(["deploy", target, "--offline", "--no-gitignore"], cwd);
 			expect(existsSync(join(target, ".mycode/instructions.md"))).toBe(true);
 
-			const { exitCode } = run(
-				["undeploy", target, "--force", "--no-gitignore"],
-				cwd,
-			);
+			const { exitCode } = run(["undeploy", target, "--force"], cwd);
 			expect(exitCode).toBe(0);
 			expect(existsSync(join(target, ".mycode/instructions.md"))).toBe(false);
 		} finally {
@@ -308,10 +286,7 @@ test.describe("undeploy CLI – PATH argument", () => {
 		const cwd = makeTmpDir();
 		const target = makeTmpDir(); // exists but has no .dotagents
 		try {
-			const { exitCode, stderr } = run(
-				["undeploy", target, "--force", "--no-gitignore"],
-				cwd,
-			);
+			const { exitCode, stderr } = run(["undeploy", target, "--force"], cwd);
 			expect(exitCode).not.toBe(0);
 			expect(stderr).toContain(".dotagents");
 		} finally {
@@ -471,7 +446,7 @@ test.describe("undeploy TUI – T-U3 edited file No", () => {
 	run(["deploy", "--offline", "--no-gitignore"], d);
 	// Simulate user editing a deployed file after deploy
 	writeFileSync(join(d, ".mycode/instructions.md"), "User edited this.");
-	test.use({ program: shellProgram(d, ["undeploy", "--no-gitignore"]) });
+	test.use({ program: shellProgram(d, ["undeploy"]) });
 
 	test("default No on edited-file prompt keeps the file", async ({
 		terminal,
@@ -502,7 +477,7 @@ test.describe("undeploy TUI – T-U4 edited file Yes", () => {
 	initWithLocalProvider(d);
 	run(["deploy", "--offline", "--no-gitignore"], d);
 	writeFileSync(join(d, ".mycode/instructions.md"), "User edited this.");
-	test.use({ program: shellProgram(d, ["undeploy", "--no-gitignore"]) });
+	test.use({ program: shellProgram(d, ["undeploy"]) });
 
 	test("selecting Yes on edited-file prompt deletes the file", async ({
 		terminal,
@@ -540,7 +515,7 @@ test.describe("undeploy CLI – missing deployed file", () => {
 			// Manually delete one deployed file
 			unlinkSync(join(d, ".mycode/instructions.md"));
 
-			const { exitCode } = run(["undeploy", "--force", "--no-gitignore"], d);
+			const { exitCode } = run(["undeploy", "--force"], d);
 			expect(exitCode).toBe(0);
 			// Remaining files should be deleted
 			expect(existsSync(join(d, ".mycode/commands/hello.md"))).toBe(false);

--- a/tests/integration/undeploy.rs
+++ b/tests/integration/undeploy.rs
@@ -22,8 +22,7 @@ fn undeploy_removes_deployed_files_and_clears_cache() {
         "instructions.md should exist after deploy"
     );
 
-    ws.run_command(&["undeploy", "--no-gitignore"])
-        .assert_success();
+    ws.run_command(&["undeploy"]).assert_success();
 
     assert!(
         !ws.file_exists(".mycode/instructions.md"),
@@ -48,43 +47,16 @@ fn undeploy_with_no_cache_exits_cleanly() {
     init_with_mycode_provider(&ws);
 
     // Do NOT deploy — no cache.toml exists.
-    ws.run_command(&["undeploy", "--no-gitignore"])
-        .assert_success();
+    ws.run_command(&["undeploy"]).assert_success();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// --no-gitignore flag
+// Gitignore fence cleanup on undeploy
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn undeploy_no_gitignore_leaves_fence_intact() {
-    // --no-gitignore preserves the .gitignore managed fence.
-    let ws = TestWorkspace::new();
-    init_with_mycode_provider(&ws);
-
-    ws.run_command(&["deploy", "--offline", "--gitignore"])
-        .assert_success();
-
-    // Fence should now exist.
-    let gi_before = ws.read_file(".gitignore");
-    assert!(
-        gi_before.contains("region dotagents"),
-        ".gitignore should contain managed fence after deploy"
-    );
-
-    ws.run_command(&["undeploy", "--no-gitignore"])
-        .assert_success();
-
-    let gi_after = ws.read_file(".gitignore");
-    assert!(
-        gi_after.contains("region dotagents"),
-        ".gitignore fence should be preserved with --no-gitignore"
-    );
-}
-
-#[test]
-fn undeploy_removes_gitignore_fence_by_default() {
-    // Without --no-gitignore, undeploy removes the managed fence.
+fn undeploy_removes_gitignore_fence() {
+    // Undeploy always removes the managed fence from .gitignore.
     let ws = TestWorkspace::new();
     init_with_mycode_provider(&ws);
 
@@ -124,8 +96,7 @@ fn no_cache_deploy_then_undeploy_works() {
         "instructions.md should exist after --no-cache deploy"
     );
 
-    ws.run_command(&["undeploy", "--no-gitignore"])
-        .assert_success();
+    ws.run_command(&["undeploy"]).assert_success();
 
     assert!(
         !ws.file_exists(".mycode/instructions.md"),
@@ -146,12 +117,10 @@ fn undeploy_twice_is_safe() {
     ws.run_command(&["deploy", "--offline", "--no-gitignore"])
         .assert_success();
 
-    ws.run_command(&["undeploy", "--no-gitignore"])
-        .assert_success();
+    ws.run_command(&["undeploy"]).assert_success();
 
     // Second undeploy — cache is already empty.
-    ws.run_command(&["undeploy", "--no-gitignore"])
-        .assert_success();
+    ws.run_command(&["undeploy"]).assert_success();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -172,8 +141,7 @@ fn undeploy_prunes_empty_parent_directory() {
         ".mycode/commands should exist after deploy"
     );
 
-    ws.run_command(&["undeploy", "--no-gitignore"])
-        .assert_success();
+    ws.run_command(&["undeploy"]).assert_success();
 
     assert!(
         !ws.dir_exists(".mycode/commands"),
@@ -199,8 +167,7 @@ fn undeploy_skips_user_edited_file_in_non_tty() {
     fs::write(&out_path, "User has edited this file.").unwrap();
 
     // stdin is null (non-TTY) in run_command; edited file should be skipped.
-    ws.run_command(&["undeploy", "--no-gitignore"])
-        .assert_success();
+    ws.run_command(&["undeploy"]).assert_success();
 
     assert!(
         ws.file_exists(".mycode/instructions.md"),
@@ -220,8 +187,7 @@ fn undeploy_force_deletes_user_edited_file() {
     let out_path = ws.root().join(".mycode/instructions.md");
     fs::write(&out_path, "User has edited this file.").unwrap();
 
-    ws.run_command(&["undeploy", "--no-gitignore", "--force"])
-        .assert_success();
+    ws.run_command(&["undeploy", "--force"]).assert_success();
 
     assert!(
         !ws.file_exists(".mycode/instructions.md"),


### PR DESCRIPTION
## Summary

- Add `--deploy` flag to `add-command`, `rm-command`, `add-skill`, and `rm-skill` subcommands to explicitly opt into auto-deploy after mutation (mutually exclusive with `--no-deploy`)
- Update `maybe_prompt_deploy` to accept a `force_deploy` parameter — when `--deploy` is set or not in a TTY, deploy runs automatically without prompting
- Drop `--no-gitignore` from `undeploy` — undeploy now unconditionally cleans up the managed `.gitignore` fence
- Remove the corresponding `--no-gitignore` integration test case (`undeploy_no_gitignore_leaves_fence_intact`)
- Update all integration and e2e test invocations to reflect the removed flag

## Testing

- Unit tests updated in `commands.rs` and `skills.rs` to pass the new `force_deploy` parameter to `maybe_prompt_deploy`
- Integration tests in `tests/integration/undeploy.rs` updated: removed `--no-gitignore` from all `undeploy` invocations, renamed fence-cleanup test
- E2E tests in `tests/e2e/undeploy.test.ts` updated: dropped `--no-gitignore` from all `run()` calls and removed the U05 preserve-fence test case, renumbered remaining tests