### PR TITLE
Show deploy summary in all exit paths instead of generic 'Done'

### DIFF
--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -4,7 +4,9 @@ use serde_json::{Value, to_value};
 use std::sync::{Arc, Mutex};
 
 use crate::cli::options::DeployOptions;
-use crate::cli::ui::deploy::{print_deploy_summary, prompt_gitignore_update, prompt_offline};
+use crate::cli::ui::deploy::{
+    deploy_outro, print_deploy_summary, prompt_gitignore_update, prompt_offline,
+};
 use crate::cli::ui::dry_run::{
     DeployDryRunStatus, DryRunDeployEntry, print_dry_run_deploy_summary,
 };
@@ -299,13 +301,12 @@ pub(super) fn deploy(mut opts: DeployOptions) -> Result<()> {
         .save()
         .context("unable to save cache")?;
 
-    // Print deploy summary before the gitignore step.
-    print_deploy_summary(&stats);
-
     // Skip gitignore update only when the user opted out.
     if opts.no_gitignore {
         if is_tui_enabled() {
-            outro("Done.").ok();
+            outro(deploy_outro(&stats)).ok();
+        } else {
+            print_deploy_summary(&stats);
         }
         return Ok(());
     }
@@ -315,7 +316,9 @@ pub(super) fn deploy(mut opts: DeployOptions) -> Result<()> {
 
     if cache_targets.is_empty() {
         if is_tui_enabled() {
-            outro("Done.").ok();
+            outro(deploy_outro(&stats)).ok();
+        } else {
+            print_deploy_summary(&stats);
         }
         return Ok(());
     }
@@ -331,7 +334,9 @@ pub(super) fn deploy(mut opts: DeployOptions) -> Result<()> {
     }
 
     if is_tui_enabled() {
-        outro("Done.").ok();
+        outro(deploy_outro(&stats)).ok();
+    } else {
+        print_deploy_summary(&stats);
     }
 
     Ok(())

--- a/src/cli/ui/deploy.rs
+++ b/src/cli/ui/deploy.rs
@@ -64,9 +64,9 @@ pub(crate) fn prompt_gitignore_update(new_path_count: usize) -> bool {
 /// Formats deploy summary as a string for use with `cliclack::outro`.
 pub(crate) fn deploy_outro(stats: &DeployStats) -> String {
     if stats.written == 0 && stats.skipped == 0 {
-        "Nothing deployed.".to_string()
+        "Nothing deployed".to_string()
     } else {
-        format!("{} written, {} skipped.", stats.written, stats.skipped)
+        format!("{} written, {} skipped", stats.written, stats.skipped)
     }
 }
 

--- a/src/cli/ui/deploy.rs
+++ b/src/cli/ui/deploy.rs
@@ -61,6 +61,15 @@ pub(crate) fn prompt_gitignore_update(new_path_count: usize) -> bool {
     sel.interact().unwrap_or(false)
 }
 
+/// Formats deploy summary as a string for use with `cliclack::outro`.
+pub(crate) fn deploy_outro(stats: &DeployStats) -> String {
+    if stats.written == 0 && stats.skipped == 0 {
+        "Nothing deployed.".to_string()
+    } else {
+        format!("{} written, {} skipped.", stats.written, stats.skipped)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/e2e/commands.test.ts
+++ b/tests/e2e/commands.test.ts
@@ -918,6 +918,10 @@ test.describe("commands new TUI – T07 deploy on Yes", () => {
 			terminal.keyPress("Enter"); // Yes to deploy
 			await expect(terminal.getByText("Run in offline mode?")).toBeVisible();
 			terminal.keyPress("Enter"); // accept online
+			await expect(
+				terminal.getByText("deployed path(s) to .gitignore?"),
+			).toBeVisible();
+			terminal.keyPress("Enter"); // accept default No
 			await expect(terminal.getByText("written")).toBeVisible();
 			expect(existsSync(join(d, ".mycode/commands/deploy-test-cmd.md"))).toBe(
 				true,

--- a/tests/e2e/deploy.test.ts
+++ b/tests/e2e/deploy.test.ts
@@ -597,7 +597,7 @@ test.describe("deploy TUI – T-GP01 gitignore prompt No", () => {
 				terminal.getByText("deployed path(s) to .gitignore?"),
 			).toBeVisible();
 			terminal.keyPress("Enter"); // accept default No
-			await expect(terminal.getByText("Done.")).toBeVisible();
+			await expect(terminal.getByText("written")).toBeVisible();
 			// .gitignore should NOT contain the dotagents fence
 			const giPath = join(d, ".gitignore");
 			if (existsSync(giPath)) {
@@ -623,7 +623,7 @@ test.describe("deploy TUI – T-GP02 gitignore prompt Yes", () => {
 			).toBeVisible();
 			terminal.keyDown(); // navigate to Yes
 			terminal.keyPress("Enter");
-			await expect(terminal.getByText("Done.")).toBeVisible();
+			await expect(terminal.getByText("written")).toBeVisible();
 			const gi = readFileSync(join(d, ".gitignore"), "utf8");
 			expect(gi).toContain("region dotagents");
 		} finally {
@@ -809,7 +809,7 @@ test.describe("deploy TUI – TC-DEPLOY-16 offline prompt Yes", () => {
 				terminal.getByText("deployed path(s) to .gitignore?"),
 			).toBeVisible();
 			terminal.keyPress("Enter");
-			await expect(terminal.getByText("Done.")).toBeVisible();
+			await expect(terminal.getByText("written")).toBeVisible();
 			expect(existsSync(join(d, ".mycode/commands/hello.md"))).toBe(true);
 		} finally {
 			cleanup(d);
@@ -839,7 +839,6 @@ test.describe("deploy TUI – TC-DEPLOY-01 full deploy journey", () => {
 			terminal.keyPress("Enter");
 
 			await expect(terminal.getByText("written")).toBeVisible();
-			await expect(terminal.getByText("Done.")).toBeVisible();
 			expect(existsSync(join(d, ".mycode/commands/hello.md"))).toBe(true);
 			expect(existsSync(join(d, ".mycode/instructions.md"))).toBe(true);
 		} finally {


### PR DESCRIPTION
## Summary

- Replaced the generic `Done.` outro with a deploy summary (e.g. `3 written, 0 skipped.`) shown at every exit path in `deploy`
- Added `deploy_outro` helper in `src/cli/ui/deploy.rs` that formats the summary string from `DeployStats`
- Prints `Nothing deployed.` when zero files were written or skipped
- Updated e2e tests to assert on `written` text instead of `Done.` in TUI deploy flows

## Testing

- `mise tests:e2e` — all deploy and commands TUI tests pass with updated assertions (`written` instead of `Done.`)
- `mise tests` — full test suite passes (unit + integration + e2e)
- `mise check` — no clippy warnings or formatting issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment completion messages now display detailed statistics showing how many items were written and skipped, instead of a generic completion message. This provides clearer feedback on deployment results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soorya-u/dotagents/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->