### PR TITLE
Add debug logging for selected provider targets in init wizard

### DIFF
--- a/src/cli/ui/init.rs
+++ b/src/cli/ui/init.rs
@@ -1,3 +1,4 @@
+use crate::prelude::*;
 use anyhow::{Context, Result};
 use cliclack::{multiselect, outro, outro_cancel, select, spinner};
 
@@ -66,6 +67,10 @@ pub(crate) fn run_init_wizard(opts: &mut InitOptions, dir_exists: bool) -> Resul
 
     if opts.targets.is_none() {
         opts.targets = prompt_targets(&[])?.or(Some(vec![]));
+    }
+
+    if let Some(ref targets) = opts.targets {
+        debug!("Selected provider targets: {:?}", targets);
     }
 
     Ok(true)


### PR DESCRIPTION
Logs the full list of provider targets selected during the interactive init wizard at debug level. This helps users verify all selections were captured correctly when cliclack's multiselect summary truncates the displayed items.

Closes #117