### PR TITLE
Drop `--offline` mode for `providers ls`, always fetch registry

### DIFF
--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -120,10 +120,6 @@ pub(crate) struct ProvidersLsOptions {
     /// Output as JSON array instead of text.
     #[clap(long)]
     pub json: bool,
-
-    /// Read registry from cache only; error if cache is cold.
-    #[clap(long)]
-    pub offline: bool,
 }
 
 /// Shared workspace path argument for `--cwd`.

--- a/src/cli/providers.rs
+++ b/src/cli/providers.rs
@@ -1,11 +1,9 @@
 use cliclack::{outro, select, spinner};
 use serde::Serialize;
 
-use crate::constants::{domain::registry_url, file::REGISTRY_FILE};
+use crate::constants::domain::registry_url;
 use crate::prelude::*;
 use crate::schema::registry::Registry;
-use crate::utils::path::get_global_template_cache_dir;
-use crate::utils::tui::is_tty;
 use crate::utils::tui::is_tui_enabled;
 
 use super::options::ProvidersLsOptions;
@@ -18,31 +16,8 @@ struct DisplayProvider {
     url: Option<String>,
 }
 
-/// Persist the fetched registry JSON to the template-source cache so offline
-/// mode can read it back.
-fn cache_registry(registry_json: &str) {
-    match get_global_template_cache_dir() {
-        Ok(cache_dir) => {
-            let path = cache_dir.join(REGISTRY_FILE);
-            if let Err(e) = std::fs::write(&path, registry_json) {
-                warn!("Failed to cache registry: {}", e);
-            } else {
-                debug!("Registry cached at {}", path.display());
-            }
-        }
-        Err(e) => {
-            warn!("Failed to get cache dir: {}", e);
-        }
-    }
-}
-
-/// Fetch the registry: online by default, then cache it.  Cache-only when
-/// `offline` is true.
-fn fetch_registry(offline: bool) -> Result<Registry> {
-    if offline {
-        return read_registry_from_cache();
-    }
-
+/// Fetch the provider registry from the remote URL.
+fn fetch_registry() -> Result<Registry> {
     let url = registry_url();
     debug!("Fetching provider registry from {}", url);
     let body = crate::utils::http::do_get(url)
@@ -51,29 +26,7 @@ fn fetch_registry(offline: bool) -> Result<Registry> {
     let registry: Registry = serde_json::from_str(&body)
         .with_context(|| format!("Failed to parse registry JSON from {}", url))?;
 
-    // Cache only after successful parse to avoid poisoning offline cache with bad payloads.
-    cache_registry(&body);
     Ok(registry)
-}
-
-/// Read `registry.json` from the template-source cache directory.
-fn read_registry_from_cache() -> Result<Registry> {
-    let cache_dir =
-        get_global_template_cache_dir().context("unable to get template cache directory")?;
-    let cache_path = cache_dir.join(REGISTRY_FILE);
-    debug!(
-        "Reading provider registry from cache at {}",
-        cache_path.display()
-    );
-
-    let body = std::fs::read_to_string(&cache_path).map_err(|_| {
-        anyhow!(
-            "No cached registry found at {} — run `dotagents providers` without --offline first",
-            cache_path.display()
-        )
-    })?;
-
-    serde_json::from_str(&body).with_context(|| "Failed to parse cached registry JSON")
 }
 
 fn collect_providers(registry: &Registry) -> Vec<DisplayProvider> {
@@ -91,7 +44,7 @@ fn collect_providers(registry: &Registry) -> Vec<DisplayProvider> {
     providers
 }
 
-/// Output providers as plain text.
+/// Output providers as plain text in CI format: `Name [slug] (url)`.
 fn print_text(providers: &[DisplayProvider]) {
     if providers.is_empty() {
         println!("No providers found.");
@@ -102,10 +55,10 @@ fn print_text(providers: &[DisplayProvider]) {
         let name = p.name.as_deref().unwrap_or("");
         let url = p.url.as_deref().unwrap_or("");
         match (name.is_empty(), url.is_empty()) {
-            (false, false) => println!("{}  ({}) \u{2014} {}", p.slug, name, url),
-            (false, true) => println!("{}  ({})", p.slug, name),
-            (true, false) => println!("{}  \u{2014} {}", p.slug, url),
-            (true, true) => println!("{}", p.slug),
+            (false, false) => println!("{} [{}] ({})", name, p.slug, url),
+            (false, true) => println!("{} [{}]", name, p.slug),
+            (true, false) => println!("[{}] ({})", p.slug, url),
+            (true, true) => println!("[{}]", p.slug),
         }
     }
 }
@@ -258,40 +211,32 @@ mod tests {
         assert!(roo["url"].is_null());
     }
 
-    // read_registry_from_cache errors with clear message when cache is cold
+    // print_text does not panic with mixed name/url presence
     #[test]
-    fn read_registry_from_cache_cold_cache_errors() {
-        let result = read_registry_from_cache();
-        // May succeed if there happens to be a cached registry in CI;
-        // just ensure the function exists and either succeeds or errors with the right message.
-        if let Err(e) = result {
-            let msg = e.to_string();
-            assert!(
-                msg.contains("cached registry"),
-                "error should mention 'cached registry', got: {}",
-                msg
-            );
-            assert!(
-                msg.contains("dotagents providers"),
-                "error should mention 'dotagents providers', got: {}",
-                msg
-            );
-            assert!(
-                !msg.contains("dotagents providers ls"),
-                "error should NOT mention 'dotagents providers ls', got: {}",
-                msg
-            );
-        }
+    fn print_text_does_not_panic() {
+        let providers = vec![
+            DisplayProvider {
+                slug: "claude".into(),
+                name: Some("Claude Code".into()),
+                url: Some("https://docs.anthropic.com/en/docs/claude-code".into()),
+            },
+            DisplayProvider {
+                slug: "roo".into(),
+                name: None,
+                url: None,
+            },
+        ];
+        print_text(&providers);
     }
 }
 
 /// Handle `dotagents providers`.
 pub(crate) fn run_providers(opts: ProvidersLsOptions, quiet: bool) -> Result<bool> {
-    let registry = if is_tty() && is_tui_enabled() && !opts.offline && !opts.json {
+    let registry = if is_tui_enabled() && !opts.json {
         let sp = spinner();
         sp.start("Fetching providers…");
         debug!("Fetching provider registry from {}", registry_url());
-        match fetch_registry(false) {
+        match fetch_registry() {
             Ok(r) => {
                 sp.clear();
                 r
@@ -302,10 +247,8 @@ pub(crate) fn run_providers(opts: ProvidersLsOptions, quiet: bool) -> Result<boo
             }
         }
     } else {
-        if opts.offline {
-            debug!("Using offline mode for provider registry");
-        }
-        fetch_registry(opts.offline).context("unable to load provider registry")?
+        debug!("Fetching provider registry from {}", registry_url());
+        fetch_registry().context("unable to load provider registry")?
     };
 
     let providers = collect_providers(&registry);
@@ -328,7 +271,7 @@ pub(crate) fn run_providers(opts: ProvidersLsOptions, quiet: bool) -> Result<boo
         return Ok(true);
     }
 
-    if is_tty() {
+    if is_tui_enabled() {
         return run_tui(&providers);
     }
 

--- a/src/constants/file.rs
+++ b/src/constants/file.rs
@@ -3,7 +3,6 @@ pub(crate) const MCP_FILE: &str = "mcp.jsonc";
 pub(crate) const GLOBAL_CONFIG_FILE: &str = "config.toml";
 pub(crate) const LOCAL_CONFIG_FILE: &str = "local.config.toml";
 pub(crate) const CACHE_CONFIG_FILE: &str = "cache.toml";
-pub(crate) const REGISTRY_FILE: &str = "registry.json";
 
 pub(crate) const GITIGNORE_FILE: &str = ".gitignore";
 pub(crate) const ENV_FILE: &str = ".env";

--- a/tests/e2e/providers.test.ts
+++ b/tests/e2e/providers.test.ts
@@ -1,11 +1,5 @@
 import { expect, test } from "@microsoft/tui-test";
-import {
-	cleanup,
-	makeTmpDir,
-	run,
-	seedRegistryCache,
-	shellProgram,
-} from "./helpers.js";
+import { cleanup, makeTmpDir, run, shellProgram } from "./helpers.js";
 
 test.describe("providers ls CLI", () => {
 	// --json exits 0 and returns a valid JSON array with slug/name/url fields
@@ -27,76 +21,27 @@ test.describe("providers ls CLI", () => {
 		}
 	});
 
-	// --json --offline with seeded cache returns providers with name and url populated
-	test("--json --offline with seeded cache returns populated name and url", async () => {
+	// default text output lists providers in Name [slug] (url) format
+	test("default text output contains provider slugs in brackets", async () => {
 		const d = makeTmpDir();
-		const xdgDir = seedRegistryCache();
 		try {
-			const { exitCode, stdout } = run(
-				["providers", "--json", "--offline"],
-				d,
-				{ XDG_CONFIG_HOME: xdgDir },
-			);
+			const { exitCode, stdout } = run(["providers", "--ci"], d);
 			expect(exitCode).toBe(0);
-			const parsed = JSON.parse(stdout);
-			const claude = parsed.find((p: { slug: string }) => p.slug === "claude");
-			expect(claude).toBeDefined();
-			expect(claude.name).toBe("Claude Code");
-			expect(claude.url).toBe("https://docs.anthropic.com/en/docs/claude-code");
+			expect(stdout).toContain("[claude]");
+			expect(stdout).toContain("[amp]");
 		} finally {
 			cleanup(d);
-			cleanup(xdgDir);
 		}
 	});
 
-	// default text output lists slugs and names
-	test("default text output --offline contains provider slugs", async () => {
+	// --verbose shows debug line with registry URL
+	test("-v shows debug line with registry URL", async () => {
 		const d = makeTmpDir();
-		const xdgDir = seedRegistryCache();
 		try {
-			const { exitCode, stdout } = run(["providers", "--offline"], d, {
-				XDG_CONFIG_HOME: xdgDir,
-			});
-			expect(exitCode).toBe(0);
-			expect(stdout).toContain("claude");
-			expect(stdout).toContain("amp");
-		} finally {
-			cleanup(d);
-			cleanup(xdgDir);
-		}
-	});
-
-	// --offline with cold cache exits non-zero with a helpful error message
-	test("--offline with cold cache exits non-zero with cached registry error", async () => {
-		const d = makeTmpDir();
-		const xdgDir = makeTmpDir(); // empty — no registry seeded
-		try {
-			const { exitCode, stderr } = run(["providers", "--offline"], d, {
-				XDG_CONFIG_HOME: xdgDir,
-			});
-			expect(exitCode).not.toBe(0);
-			expect(stderr).toContain("cached registry");
-			expect(stderr).toContain("dotagents providers");
-			expect(stderr).not.toContain("dotagents providers ls");
-		} finally {
-			cleanup(d);
-			cleanup(xdgDir);
-		}
-	});
-
-	// --verbose with cold cache shows debug line with registry URL before failing
-	test("-v with cold cache shows debug line with registry URL", async () => {
-		const d = makeTmpDir();
-		const xdgDir = makeTmpDir(); // empty — no registry seeded
-		try {
-			const { stderr } = run(["-v", "providers"], d, {
-				XDG_CONFIG_HOME: xdgDir,
-			});
-			// Should attempt fetch (showing debug URL) then fail with cache error
+			const { stderr } = run(["-v", "providers"], d);
 			expect(stderr).toMatch(/Fetching provider registry from https?:\/\//);
 		} finally {
 			cleanup(d);
-			cleanup(xdgDir);
 		}
 	});
 });
@@ -104,41 +49,29 @@ test.describe("providers ls CLI", () => {
 // ── Providers --quiet / --verbose ─────────────────────────────────────────────
 
 test.describe("providers CLI – --quiet flag", () => {
-	// TC-PROV-09: --quiet suppresses provider listing output
-	test("--quiet --offline with seeded cache produces empty stdout", async () => {
+	// --quiet suppresses provider listing output
+	test("--quiet produces empty stdout", async () => {
 		const d = makeTmpDir();
-		const xdgDir = seedRegistryCache();
 		try {
-			const { exitCode, stdout } = run(
-				["providers", "--ci", "--quiet", "--offline"],
-				d,
-				{ XDG_CONFIG_HOME: xdgDir },
-			);
+			const { exitCode, stdout } = run(["providers", "--ci", "--quiet"], d);
 			expect(exitCode).toBe(0);
 			expect(stdout).toBe("");
 		} finally {
 			cleanup(d);
-			cleanup(xdgDir);
 		}
 	});
 });
 
 test.describe("providers CLI – --verbose flag", () => {
-	// TC-PROV-10: -v adds diagnostic output with seeded cache
-	test("-v --offline with seeded cache shows debug output on stderr", async () => {
+	// -v adds diagnostic output
+	test("-v shows debug output on stderr", async () => {
 		const d = makeTmpDir();
-		const xdgDir = seedRegistryCache();
 		try {
-			const { exitCode, stderr } = run(
-				["providers", "--ci", "-v", "--offline"],
-				d,
-				{ XDG_CONFIG_HOME: xdgDir },
-			);
+			const { exitCode, stderr } = run(["providers", "--ci", "-v"], d);
 			expect(exitCode).toBe(0);
-			expect(stderr).toMatch(/cache|Cache|CACHE|offline|Offline/);
+			expect(stderr).toMatch(/cache|Cache|CACHE|fetch|Fetch/);
 		} finally {
 			cleanup(d);
-			cleanup(xdgDir);
 		}
 	});
 });
@@ -148,11 +81,8 @@ test.describe("providers CLI – --verbose flag", () => {
 // TC-PROV-01: TUI select widget renders and is navigable
 test.describe("providers TUI – TC-PROV-01 select widget", () => {
 	const d = makeTmpDir();
-	const xdgDir = seedRegistryCache();
 	test.use({
-		program: shellProgram(d, ["providers", "--offline"], {
-			XDG_CONFIG_HOME: xdgDir,
-		}),
+		program: shellProgram(d, ["providers"]),
 	});
 
 	test("select widget renders, Enter selects, shows outro", async ({
@@ -170,7 +100,6 @@ test.describe("providers TUI – TC-PROV-01 select widget", () => {
 			await expect(terminal.getByText("Amp Code")).toBeVisible();
 		} finally {
 			cleanup(d);
-			cleanup(xdgDir);
 		}
 	});
 });


### PR DESCRIPTION
## Summary

- Removes the `--offline` flag and all offline/cache machinery from `providers ls`
- Registry is always fetched from the remote URL on every invocation
- Deletes `cache_registry`, `read_registry_from_cache`, and the `REGISTRY_FILE` constant
- Changes plain-text output format from `slug (name) — url` to `Name [slug] (url)` for consistency with CI output expectations
- Switches TTY detection from `is_tty()` to `is_tui_enabled()` in the providers run path
- Removes stale e2e tests that relied on offline mode and seeded cache directories

## Testing

- `mise check` — format and clippy pass
- `mise tests` — all unit, integration, and e2e tests pass
- Manual: `dotagents providers` fetches and displays the live registry
- Manual: `dotagents providers --json` returns valid JSON array with slug/name/url fields
- Manual: `dotagents providers --ci` outputs `Name [slug] (url)` format without TUI