### PR TITLE
Add GitHub issue templates for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report broken behavior, regressions, crashes, or reliability issues.
+title: "[Bug]: "
+labels:
+  - bug
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for broken behavior, regressions, crashes, or reliability problems.
+        Search existing issues first and keep the report focused on one problem.
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal, deterministic repro.
+      placeholder: |
+        1. Run `dotagents init`
+        2. Edit config.toml with ...
+        3. Run `dotagents deploy`
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: Deploy should render the template and write the output file.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: The command panics with an error about missing template.
+      render: markdown
+    validations:
+      required: true
+
+  - type: input
+    id: version_env
+    attributes:
+      label: Version and environment
+      description: Commit SHA or release version, plus OS and Rust version.
+      placeholder: v0.3.1, macOS 15.3, rustc 1.85.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or stack traces
+      description: Paste the most relevant output only. Redact secrets.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Propose a scoped improvement or new capability.
+title: "[Feature]: "
+labels:
+  - enhancement
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for new capabilities or meaningful improvements to existing behavior.
+        Small, concrete requests that clearly explain the problem and scope are much easier to evaluate.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do? What is hard, slow, or impossible today?
+      placeholder: I want to deploy to a custom provider that isn't in the built-in list.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior, API, or UX you want.
+      placeholder: Allow custom provider definitions in config.toml with a template path and target path.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: value
+    attributes:
+      label: Why this matters
+      description: Who benefits, and what outcome does this unlock?
+      placeholder: Teams using internal tools could integrate dotagents without forking the project.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Smallest useful scope
+      description: What is the narrowest version of this request that would still solve your problem?
+      placeholder: A first pass only needs to support a single custom provider with static template paths.
+      render: markdown
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

- Add structured bug report template with required fields for steps, expected/actual behavior, version, and logs
- Add feature request template with required fields for problem, proposal, value, and scope
- Both templates auto-label issues (`bug` / `enhancement` + `needs-triage`) and include guidance to search existing issues first

## Testing

- Not run (GitHub issue templates are validated by GitHub's form renderer at issue creation time; no CI tests apply)