### PR TITLE
gate skills-add behind `skills-add` Cargo feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ keywords = ["dotagents", "configuration", "dotfiles", "agent"]
 categories = ["command-line-utilities"]
 edition = "2024"
 
+[features]
+default = []
+skills-add = []
+
 [dependencies]
 anyhow = "1.0.100"
 clap = { version = "4.5.48", features = ["derive"] }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -287,6 +287,7 @@ fn print_app_config(config: &AppConfig) {
         }
     }
 
+    #[cfg(feature = "skills-add")]
     if let Some(runner) = &config.package_runner {
         println!(
             "\nPackage runner: {}",

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -2,6 +2,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use std::path::PathBuf;
 
+#[cfg(feature = "skills-add")]
 use crate::core::config::common::PackageRunner;
 
 #[derive(Parser, Default)]
@@ -92,6 +93,7 @@ impl Feature {
 #[derive(Subcommand)]
 pub(crate) enum SkillsAction {
     /// Install a skill from skills.sh or a GitHub owner/repo into .dotagents/skills/
+    #[cfg(feature = "skills-add")]
     Add(SkillsAddOptions),
     /// Create a new skill scaffold
     New(AddSkillOptions),
@@ -150,6 +152,7 @@ pub(crate) struct SubLsOptions {
     pub skill: Option<String>,
 }
 
+#[cfg(feature = "skills-add")]
 #[derive(Args)]
 pub(crate) struct SkillsAddOptions {
     #[clap(flatten)]

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -31,6 +31,7 @@ pub(crate) fn run(opts: Options) -> Result<bool> {
             true
         }
         Action::Skills { action } => match action {
+            #[cfg(feature = "skills-add")]
             SkillsAction::Add(opts) => {
                 skills::add(opts).context("complete 'skills add' command")?
             }

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -1,19 +1,23 @@
 use anyhow::{Context, Result, bail};
 use cliclack::{confirm, input, outro};
 use std::fs;
+#[cfg(feature = "skills-add")]
 use std::io::ErrorKind;
 
 use crate::cli::deploy::deploy;
-use crate::cli::options::{
-    AddSkillOptions, DeployOptions, RmSkillOptions, SkillsAddOptions, SubLsOptions,
-};
+#[cfg(feature = "skills-add")]
+use crate::cli::options::SkillsAddOptions;
+use crate::cli::options::{AddSkillOptions, DeployOptions, RmSkillOptions, SubLsOptions};
 use crate::cli::ui::ls::render_skills;
 use crate::core::config::CacheConfig;
+#[cfg(feature = "skills-add")]
 use crate::core::config::app::AppConfig;
+#[cfg(feature = "skills-add")]
 use crate::core::config::common::PackageRunner;
 use crate::core::features::skill::SkillFeature;
 use crate::prelude::*;
 use crate::schema::list_item::ListItem;
+#[cfg(feature = "skills-add")]
 use crate::templates::get_templater;
 use crate::utils::fs::write_file;
 use crate::utils::path::{
@@ -57,6 +61,7 @@ fn maybe_prompt_deploy(force_deploy: bool, no_deploy: bool) -> Result<()> {
 }
 
 /// Install a skill into `.dotagents/skills/` by wrapping the `skills` CLI.
+#[cfg(feature = "skills-add")]
 pub(crate) fn add(opts: SkillsAddOptions) -> Result<bool> {
     resolve_and_override_workspace(opts.workspace.cwd)
         .context("unable to resolve workspace directory")?;

--- a/src/core/config/app.rs
+++ b/src/core/config/app.rs
@@ -2,7 +2,9 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result};
 
-use super::common::{PackageRunner, Providers};
+#[cfg(feature = "skills-add")]
+use super::common::PackageRunner;
+use super::common::Providers;
 use super::global::GlobalConfig;
 use super::local::LocalConfig;
 use crate::constants::file::{GLOBAL_CONFIG_FILE, LOCAL_CONFIG_FILE};
@@ -23,6 +25,7 @@ pub struct AppConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub providers: Option<Providers>,
     pub variables: Option<HashMap<String, String>>,
+    #[cfg(feature = "skills-add")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package_runner: Option<PackageRunner>,
 }
@@ -35,6 +38,7 @@ impl AppConfig {
             targets: HashSet::new(),
             providers: None,
             variables: None,
+            #[cfg(feature = "skills-add")]
             package_runner: None,
         }
     }
@@ -135,6 +139,7 @@ impl From<(&GlobalConfig, &LocalConfig)> for AppConfig {
             },
         );
 
+        #[cfg(feature = "skills-add")]
         let package_runner = local
             .package_runner
             .clone()
@@ -146,6 +151,7 @@ impl From<(&GlobalConfig, &LocalConfig)> for AppConfig {
             targets,
             providers,
             variables,
+            #[cfg(feature = "skills-add")]
             package_runner,
         }
     }
@@ -160,7 +166,7 @@ impl Default for AppConfig {
 #[cfg(debug_assertions)]
 impl TomlConfig for AppConfig {}
 
-#[cfg(test)]
+#[cfg(all(test, feature = "skills-add"))]
 mod tests {
     use super::*;
     use crate::core::config::common::PackageRunner;
@@ -189,7 +195,6 @@ mod tests {
 
     #[test]
     fn local_runner_wins_over_global() {
-        // local package-runner overrides global
         let global = make_global(Some(PackageRunner::Npm));
         let local = make_local(Some(PackageRunner::Pnpm));
         let app = AppConfig::from((&global, &local));
@@ -198,7 +203,6 @@ mod tests {
 
     #[test]
     fn global_runner_used_when_local_absent() {
-        // global package-runner is used when local doesn't specify one
         let global = make_global(Some(PackageRunner::Yarn));
         let local = make_local(None);
         let app = AppConfig::from((&global, &local));
@@ -207,7 +211,6 @@ mod tests {
 
     #[test]
     fn both_absent_yields_none() {
-        // None in both configs → AppConfig.package_runner is None
         let global = make_global(None);
         let local = make_local(None);
         let app = AppConfig::from((&global, &local));
@@ -238,7 +241,6 @@ mod tests {
 
     #[test]
     fn local_targets_win_over_global() {
-        // local targets override global targets when both are present
         let global = make_global_with_targets(Some(["codex".into()].into_iter().collect()));
         let local = make_local_with_targets(Some(["claude".into()].into_iter().collect()));
         let app = AppConfig::from((&global, &local));
@@ -247,7 +249,6 @@ mod tests {
 
     #[test]
     fn global_targets_used_when_local_absent() {
-        // global targets are used when local specifies none
         let global = make_global_with_targets(Some(["codex".into()].into_iter().collect()));
         let local = make_local_with_targets(None);
         let app = AppConfig::from((&global, &local));
@@ -256,7 +257,6 @@ mod tests {
 
     #[test]
     fn both_targets_absent_yields_empty() {
-        // no targets in either config → AppConfig.targets is empty
         let global = make_global_with_targets(None);
         let local = make_local_with_targets(None);
         let app = AppConfig::from((&global, &local));

--- a/src/core/config/common.rs
+++ b/src/core/config/common.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::{core::features::Feature, utils::merge::merge_optional};
 
 /// Package runner used to invoke the `skills` CLI.
+#[cfg(feature = "skills-add")]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum PackageRunner {
@@ -13,6 +14,7 @@ pub enum PackageRunner {
     Bun,
 }
 
+#[cfg(feature = "skills-add")]
 impl PackageRunner {
     /// Returns the executable name to check on PATH and use as the first argv element.
     pub(crate) fn binary(&self) -> &str {
@@ -252,9 +254,9 @@ mod tests {
         assert!(skill_config.is_none());
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_serialises_to_lowercase() {
-        // TOML requires a key-value context; use a wrapper struct as in real usage
         #[derive(Serialize, Deserialize)]
         struct W {
             r: PackageRunner,
@@ -273,9 +275,9 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_deserialises_from_lowercase() {
-        // round-trip from TOML key-value string back to enum
         #[derive(Serialize, Deserialize)]
         struct W {
             r: PackageRunner,
@@ -291,9 +293,9 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_args_npm() {
-        // npm produces the npx-based argv
         let args = PackageRunner::Npm.args("vercel-labs/agent-skills", false);
         assert_eq!(
             args,
@@ -308,9 +310,9 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_args_npm_ci() {
-        // npm in CI mode appends --yes
         let args = PackageRunner::Npm.args("vercel-labs/agent-skills", true);
         assert_eq!(
             args,
@@ -326,9 +328,9 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_args_pnpm() {
-        // pnpm produces the dlx-based argv
         let args = PackageRunner::Pnpm.args("my-skill", false);
         assert_eq!(
             args,
@@ -344,9 +346,9 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_args_pnpm_ci() {
-        // pnpm in CI mode appends --yes
         let args = PackageRunner::Pnpm.args("my-skill", true);
         assert_eq!(
             args,
@@ -363,9 +365,9 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_args_yarn() {
-        // yarn produces the dlx-based argv
         let args = PackageRunner::Yarn.args("my-skill", false);
         assert_eq!(
             args,
@@ -381,9 +383,9 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_args_yarn_ci() {
-        // yarn in CI mode appends --yes
         let args = PackageRunner::Yarn.args("my-skill", true);
         assert_eq!(
             args,
@@ -400,9 +402,9 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_args_bun() {
-        // bun produces the bunx-based argv
         let args = PackageRunner::Bun.args("my-skill", false);
         assert_eq!(
             args,
@@ -417,9 +419,9 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_args_bun_ci() {
-        // bun in CI mode appends --yes
         let args = PackageRunner::Bun.args("my-skill", true);
         assert_eq!(
             args,

--- a/src/core/config/global.rs
+++ b/src/core/config/global.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use super::common::{PackageRunner, Providers};
+#[cfg(feature = "skills-add")]
+use super::common::PackageRunner;
+use super::common::Providers;
 use super::traits::TomlConfig;
 use crate::constants::schema::CONFIG_SCHEMA;
 use crate::core::features::Feature;
@@ -19,6 +21,7 @@ pub struct GlobalConfig {
     pub providers: Option<Providers>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub variables: Option<HashMap<String, String>>,
+    #[cfg(feature = "skills-add")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package_runner: Option<PackageRunner>,
 }
@@ -31,6 +34,7 @@ impl GlobalConfig {
             targets: None,
             providers: None,
             variables: None,
+            #[cfg(feature = "skills-add")]
             package_runner: None,
         }
     }
@@ -43,6 +47,7 @@ impl GlobalConfig {
             targets: Some(targets),
             providers: None,
             variables: None,
+            #[cfg(feature = "skills-add")]
             package_runner: None,
         }
     }
@@ -74,9 +79,9 @@ impl TomlConfig for GlobalConfig {}
 mod tests {
     use super::*;
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_field_deserialises_in_global_config() {
-        // all four runner values parse correctly from TOML
         for (toml_val, expected) in [
             ("npm", PackageRunner::Npm),
             ("pnpm", PackageRunner::Pnpm),
@@ -89,16 +94,16 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_absent_yields_none_in_global_config() {
-        // omitting the field deserialises to None
         let config: GlobalConfig = toml::from_str("features = []\n").unwrap();
         assert_eq!(config.package_runner, None);
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn invalid_package_runner_value_fails_deserialisation() {
-        // an unrecognised runner value should fail with a serde error
         let result: Result<GlobalConfig, _> = toml::from_str("package-runner = \"cargo\"\n");
         assert!(result.is_err());
     }

--- a/src/core/config/local.rs
+++ b/src/core/config/local.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use super::common::{PackageRunner, Providers};
+#[cfg(feature = "skills-add")]
+use super::common::PackageRunner;
+use super::common::Providers;
 use super::traits::TomlConfig;
 use crate::constants::schema::CONFIG_SCHEMA;
 use crate::core::features::Feature;
@@ -19,6 +21,7 @@ pub struct LocalConfig {
     pub providers: Option<Providers>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub variables: Option<HashMap<String, String>>,
+    #[cfg(feature = "skills-add")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package_runner: Option<PackageRunner>,
 }
@@ -31,6 +34,7 @@ impl LocalConfig {
             targets: None,
             providers: None,
             variables: None,
+            #[cfg(feature = "skills-add")]
             package_runner: None,
         }
     }
@@ -43,6 +47,7 @@ impl LocalConfig {
             targets: None,
             providers: None,
             variables: None,
+            #[cfg(feature = "skills-add")]
             package_runner: None,
         }
     }
@@ -55,12 +60,12 @@ impl LocalConfig {
             targets: None,
             providers: Some(providers),
             variables: None,
+            #[cfg(feature = "skills-add")]
             package_runner: None,
         }
     }
 
     pub fn validate(&self) -> anyhow::Result<()> {
-        // Check that features are valid if present
         if let Some(features) = &self.features {
             for feature in features {
                 if Feature::from_str(feature).is_none() {
@@ -74,15 +79,6 @@ impl LocalConfig {
         }
 
         Ok(())
-    }
-
-    #[allow(dead_code)]
-    pub fn is_empty(&self) -> bool {
-        self.schema.is_none()
-            && self.features.is_none()
-            && self.targets.is_none()
-            && self.providers.is_none()
-            && self.package_runner.is_none()
     }
 }
 
@@ -98,9 +94,9 @@ impl TomlConfig for LocalConfig {}
 mod tests {
     use super::*;
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_field_deserialises_in_local_config() {
-        // all four runner values parse correctly from TOML
         for (toml_val, expected) in [
             ("npm", PackageRunner::Npm),
             ("pnpm", PackageRunner::Pnpm),
@@ -113,9 +109,9 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "skills-add")]
     #[test]
     fn package_runner_absent_yields_none_in_local_config() {
-        // omitting the field deserialises to None
         let config: LocalConfig = toml::from_str("").unwrap();
         assert_eq!(config.package_runner, None);
     }

--- a/src/templates/remote.rs
+++ b/src/templates/remote.rs
@@ -379,6 +379,7 @@ mod tests {
             targets: targets.iter().map(|s| s.to_string()).collect(),
             providers: None,
             variables: None,
+            #[cfg(feature = "skills-add")]
             package_runner: None,
         }
     }

--- a/tests/e2e/skills.test.ts
+++ b/tests/e2e/skills.test.ts
@@ -838,10 +838,9 @@ test.describe("skills rm TUI – T12 confirm Yes", () => {
 });
 
 // ── skills add – CI ────────────────────────────────────────────────────────────
-
-// skills add in CI mode does not hang (non-zero exit OK — hang is the bug)
+// Gated behind the `skills-add` Cargo feature; skipped until v0.2.0 ships it.
 test.describe("skills add CI", () => {
-	test("exits promptly in CI mode (does not hang)", async () => {
+	test.skip("exits promptly in CI mode (does not hang)", async () => {
 		const d = makeTmpDir();
 		try {
 			run(["init", "--template", "starter"], d);
@@ -865,7 +864,7 @@ test.describe("skills add CI", () => {
 	});
 
 	// TC-SKILL-ADD-05: invalid --runner value exits with Clap error
-	test("--runner maven exits 2 with invalid value error", async () => {
+	test.skip("--runner maven exits 2 with invalid value error", async () => {
 		const d = makeTmpDir();
 		try {
 			run(["init", "--template", "starter"], d);
@@ -881,7 +880,7 @@ test.describe("skills add CI", () => {
 	});
 
 	// TC-SKILL-ADD-04: --runner yarn not on PATH exits non-zero with helpful error
-	test("--runner yarn not on PATH exits non-zero", async () => {
+	test.skip("--runner yarn not on PATH exits non-zero", async () => {
 		const d = makeTmpDir();
 		try {
 			run(["init", "--template", "starter"], d);


### PR DESCRIPTION
## Summary

- Add a Cargo feature flag `skills-add` (disabled by default in `Cargo.toml`)
- Gate `PackageRunner`, `SkillsAddOptions`, the `SkillsAction::Add` dispatch arm, the `skills::add()` function, and all `package_runner` config fields behind `#[cfg(feature = "skills-add")]`
- Skip the corresponding e2e `skills add` CI tests since the feature is not enabled in the default build

## Testing

- `mise check` (fmt + clippy) passes with and without `--features skills-add`
- `mise tests` (unit + integration) passes with and without `--features skills-add`
- E2E suite: `skills add` CI tests are gated with `test.skip()` since the feature is off by default; all other e2e tests continue to pass
- Manual verification: `cargo build` compiles without the `skills add` subcommand; `cargo build --features skills-add` restores it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `skills-add` optional Cargo feature flag enabling users to customize builds with or without skill addition functionality based on deployment needs and requirements, optimizing binary size and application footprint.

* **Chores**
  * Refactored skill-related commands and configuration structures to support the feature flag, reducing overall application complexity when skill functionality is not required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soorya-u/dotagents/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->