### PR TITLE
fix: flush stdout after cliclack outro/cancel messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ target   = "{{ dir.workspace }}/.myagent/commands/{{ command.name }}.md"
 ## Supported Providers
 
 14 providers with community templates:
-`amp`, `auggie`, `claude`, `codebuddy`, `codex`, `copilot`, `cursor`, `gemini`,
-`kilocode`, `opencode`, `qwen`, `roo`, `shai`, `windsurf`
+`amp`, `auggie`, `claude`, `codex`, `copilot`, `cursor`, `gemini`,
+`kilocode`, `opencode`, `qwen`
 
 Full templates at [`public/v1/templates/`](./public/v1/templates/).
 To add a new provider, contribute a `.hbs` template and `provider.toml` snippet.
@@ -117,7 +117,7 @@ To add a new provider, contribute a `.hbs` template and `provider.toml` snippet.
 
 ## Contributing
 
-This project uses [OpenSpec](https://github.com/Fission-Codes/openspec) for change
+This project uses [OpenSpec](https://github.com/Fission-AI/openspec) for change
 proposals. Check `openspec/changes/` for active work before opening a new feature.
 
 ```bash

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write;
 
 use anyhow::{Context, Result};
 use cliclack::{confirm, input, outro};
@@ -132,6 +133,7 @@ pub(crate) fn rm_command(opts: RmCommandOptions) -> Result<bool> {
 
         if !confirmed {
             outro("Cancelled.").ok();
+            let _ = std::io::stdout().flush();
             return Ok(true);
         }
     }
@@ -235,6 +237,7 @@ mod tests {
     use super::*;
     use crate::utils::tui::set_ci_mode;
     use std::fs;
+    use std::io::Write;
     use tempfile::TempDir;
 
     fn make_command(dir: &std::path::Path, name: &str, description: &str) {

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -26,6 +26,7 @@ use crate::utils::gitignore::rebuild_fence_from_cache;
 use crate::utils::path::{get_workspace_dir, override_workspace_dir};
 use crate::utils::tui::is_tui_enabled;
 use cliclack::{outro, spinner};
+use std::io::Write;
 
 /// Aggregated result of deploying one feature across all providers.
 #[derive(Debug, Default)]
@@ -305,6 +306,7 @@ pub(super) fn deploy(mut opts: DeployOptions) -> Result<()> {
     if opts.no_gitignore {
         if is_tui_enabled() {
             outro(deploy_outro(&stats)).ok();
+            let _ = std::io::stdout().flush();
         } else {
             print_deploy_summary(&stats);
         }
@@ -317,6 +319,7 @@ pub(super) fn deploy(mut opts: DeployOptions) -> Result<()> {
     if cache_targets.is_empty() {
         if is_tui_enabled() {
             outro(deploy_outro(&stats)).ok();
+            let _ = std::io::stdout().flush();
         } else {
             print_deploy_summary(&stats);
         }
@@ -335,6 +338,7 @@ pub(super) fn deploy(mut opts: DeployOptions) -> Result<()> {
 
     if is_tui_enabled() {
         outro(deploy_outro(&stats)).ok();
+        let _ = std::io::stdout().flush();
     } else {
         print_deploy_summary(&stats);
     }

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -3,6 +3,7 @@ use cliclack::{confirm, input, outro};
 use std::fs;
 #[cfg(feature = "skills-add")]
 use std::io::ErrorKind;
+use std::io::Write;
 
 use crate::cli::deploy::deploy;
 #[cfg(feature = "skills-add")]
@@ -200,6 +201,7 @@ pub(crate) fn rm_skill(opts: RmSkillOptions) -> Result<bool> {
 
         if !confirmed {
             outro("Cancelled.").ok();
+            let _ = std::io::stdout().flush();
             return Ok(true);
         }
     }

--- a/src/cli/ui/init.rs
+++ b/src/cli/ui/init.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use anyhow::{Context, Result};
 use cliclack::{multiselect, outro, outro_cancel, select, spinner};
+use std::io::Write;
 
 use crate::cli::options::{Feature, InitOptions, InitTemplate};
 use crate::schema::registry::Registry;
@@ -17,6 +18,7 @@ pub(crate) fn run_init_wizard(opts: &mut InitOptions, dir_exists: bool) -> Resul
         let overwrite = sel.interact().context("unable to get overwrite choice")?;
         if !overwrite {
             outro_cancel("Init cancelled.").ok();
+            let _ = std::io::stdout().flush();
             return Ok(false);
         }
         opts.force = true;
@@ -137,4 +139,5 @@ pub(crate) fn prompt_targets(initial: &[String]) -> Result<Option<Vec<String>>> 
 /// Shows the closing outro message after init completes successfully.
 pub(crate) fn finish_init() {
     outro("Done! Run `dotagents deploy` to render your templates.").ok();
+    let _ = std::io::stdout().flush();
 }

--- a/src/cli/ui/ls.rs
+++ b/src/cli/ui/ls.rs
@@ -1,4 +1,5 @@
 use cliclack::outro;
+use std::io::Write;
 
 use crate::cli::ui::common::{
     styled_name, styled_note_name, terminal_cols, truncate_to_width, wrap_at_width,
@@ -68,6 +69,7 @@ pub(crate) fn render_commands(items: Vec<ListItem>, content: bool) {
             println!("No commands found.");
         }
         outro("").ok();
+        let _ = std::io::stdout().flush();
         return;
     }
 
@@ -76,6 +78,7 @@ pub(crate) fn render_commands(items: Vec<ListItem>, content: bool) {
 
     render_section(&items, content, name_col, cols);
     outro(format!("{} command(s)", items.len())).ok();
+    let _ = std::io::stdout().flush();
 }
 
 /// Render the skills listing for `dotagents skills ls`.
@@ -87,6 +90,7 @@ pub(crate) fn render_skills(items: Vec<ListItem>, content: bool) {
             println!("No skills found.");
         }
         outro("").ok();
+        let _ = std::io::stdout().flush();
         return;
     }
 
@@ -95,4 +99,5 @@ pub(crate) fn render_skills(items: Vec<ListItem>, content: bool) {
 
     render_section(&items, content, name_col, cols);
     outro(format!("{} skill(s)", items.len())).ok();
+    let _ = std::io::stdout().flush();
 }

--- a/src/cli/undeploy.rs
+++ b/src/cli/undeploy.rs
@@ -1,4 +1,4 @@
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use crate::prelude::*;
@@ -81,6 +81,7 @@ pub(super) fn undeploy(mut opts: UndeployOptions) -> Result<()> {
     if !opts.force && !prompt_confirm_undeploy(entries.len()) {
         if is_tui_enabled() {
             cliclack::outro_cancel("Undeploy cancelled.").ok();
+            let _ = std::io::stdout().flush();
         }
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod schema;
 mod templates;
 pub(crate) mod utils;
 
+use std::io::Write;
+
 fn main() {
     let opts = cli::get_options();
     let ci_from_env = std::env::var("DOTAGENTS_CI")
@@ -22,6 +24,7 @@ fn main() {
             utils::display_error(e);
             if utils::logs::log_config().is_some_and(|c| c.is_tty) {
                 cliclack::outro_cancel("Fatal error").ok();
+                let _ = std::io::stdout().flush();
             }
             std::process::exit(1);
         }


### PR DESCRIPTION
## Summary

- `cliclack::outro()` and `outro_cancel()` buffer their output internally
- Without an explicit flush, messages printed just before exit (e.g. "Cancelled.", "Fatal error") could be lost
- Added `std::io::stdout().flush()` after every outro/outro_cancel call site across `deploy`, `init`, `ls`, `undeploy`, `rm`, and the main error handler
- Minor README corrections (updated provider list, fixed OpenSpec GitHub org URL)

## Testing

- Verified `outro("Cancelled.")` text appears when cancelling `dotagents command rm` and `dotagents skills rm`
- Verified deploy outro summary renders completely before exit in both TUI and non-TUI modes
- Verified `init` cancel message and success outro both flush correctly
- Verified `ls` command/skills listings flush their summary outro
- Verified `undeploy` cancel message appears before exit
- Verified fatal error `outro_cancel` flush in `main.rs`