### PR TITLE
feat(init): add Blank template, rename WithCustomProvider to Advanced, default to Blank

### DIFF
--- a/openspec/changes/archive/2026-05-19-add-init-templates/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-add-init-templates/.openspec.yaml
@@ -1,0 +1,1 @@
+id: add-init-templates

--- a/openspec/changes/archive/2026-05-19-add-init-templates/design.md
+++ b/openspec/changes/archive/2026-05-19-add-init-templates/design.md
@@ -1,0 +1,52 @@
+## Design
+
+### Template file matrix
+
+| File | Blank | Starter | Advanced |
+|------|-------|---------|----------|
+| `config.toml` | ✓ (with --features/--targets) | ✓ | ✓ |
+| `local.config.toml` | ✗ | ✓ (identical to global) | ✓ (+ mycode provider block) |
+| `.env` | ✗ | ✓ | ✓ |
+| `.gitignore` | ✓ | ✓ | ✓ |
+| Feature mocks (commands, skills, mcp, instructions) | ✓ | ✓ | ✓ |
+| `templates/mycode/*.hbs` | ✗ | ✗ | ✓ |
+
+### `InitTemplate` enum
+
+```rust
+pub(crate) enum InitTemplate {
+    /// Minimal scaffolding — config.toml, feature files, .gitignore.
+    Blank,
+    /// Ready to deploy — adds local.config.toml, .env, variables.
+    Starter,
+    /// Custom provider example — adds mycode templates and provider block.
+    Advanced,
+}
+```
+
+CLI flag values: `blank`, `starter`, `advanced` (kebab-case via `ValueEnum`).
+
+### `build_config_content` behavior
+
+- `Blank` → returns `(config_string, String::new())`; caller skips writing `local.config.toml` when local is empty.
+- `Starter` → returns `(config_string, config_string.clone())`; both written identically.
+- `Advanced` → returns `(config_string, config_string + MYCODE_PROVIDER_CONFIG)`.
+
+### Default resolution
+
+`opts.template.unwrap_or(InitTemplate::Blank)` — replaces the previous `Starter` default.
+
+### Backward compatibility
+
+- `--template starter` continues to work (same variant, same behavior).
+- `--template with-custom-provider` breaks → becomes `--template advanced`. This is acceptable as it's a pre-v1.0 CLI and the new name is clearer.
+- TUI users are unaffected (labels change but flow is identical).
+
+### TUI labels
+
+```
+Which starting template?
+  Blank       Minimal scaffolding
+  Starter     Variables, env & rendering
+  Advanced    Custom provider & overrides
+```

--- a/openspec/changes/archive/2026-05-19-add-init-templates/design.md
+++ b/openspec/changes/archive/2026-05-19-add-init-templates/design.md
@@ -7,6 +7,7 @@
 | `config.toml` | ✓ (with --features/--targets) | ✓ | ✓ |
 | `local.config.toml` | ✗ | ✓ (identical to global) | ✓ (+ mycode provider block) |
 | `.env` | ✗ | ✓ | ✓ |
+| `.env.example` | ✗ | ✓ | ✓ |
 | `.gitignore` | ✓ | ✓ | ✓ |
 | Feature mocks (commands, skills, mcp, instructions) | ✓ | ✓ | ✓ |
 | `templates/mycode/*.hbs` | ✗ | ✗ | ✓ |
@@ -44,7 +45,7 @@ CLI flag values: `blank`, `starter`, `advanced` (kebab-case via `ValueEnum`).
 
 ### TUI labels
 
-```
+```text
 Which starting template?
   Blank       Minimal scaffolding
   Starter     Variables, env & rendering

--- a/openspec/changes/archive/2026-05-19-add-init-templates/proposal.md
+++ b/openspec/changes/archive/2026-05-19-add-init-templates/proposal.md
@@ -4,7 +4,7 @@
 
 ## What Changes
 
-- **Add `Blank` template** — writes `config.toml` (reflects `--features`/`--targets`), feature mock files, `.gitignore`. Skips `.env`, `local.config.toml`, and provider templates.
+- **Add `Blank` template** — writes `config.toml` (reflects `--features`/`--targets`), feature mock files, `.gitignore`. Skips `.env`, `.env.example`, `local.config.toml`, and provider templates.
 - **Rename `WithCustomProvider` → `Advanced`** — same behavior (mycode templates + provider block in `local.config.toml`), updated CLI flag and TUI label.
 - **Keep `Starter` as-is** — already provides variables, `.env`, and `local.config.toml` with rendering-ready config. No content changes.
 - **Default template changes from `Starter` → `Blank`** — non-interactive `dotagents init` now produces minimal scaffolding.
@@ -30,7 +30,7 @@
 ## Impact
 
 - `src/cli/options.rs` — `InitTemplate` enum: add `Blank`, rename `WithCustomProvider` → `Advanced`, update `ValueEnum` labels, change default.
-- `src/cli/init.rs` — `build_config_content` handles `Blank` (no local config), file write logic skips `local.config.toml` and `.env` for `Blank`, default template resolves to `Blank`.
+- `src/cli/init.rs` — `build_config_content` handles `Blank` (no local config), file write logic skips `local.config.toml`, `.env`, and `.env.example` for `Blank`, default template resolves to `Blank`.
 - `src/cli/ui/init.rs` — TUI template selector adds `Blank` option, updates descriptions, renames `WithCustomProvider` → `Advanced`.
 - `openspec/specs/init-templates/spec.md` — updated from 2-template to 3-template spec.
 - No new dependencies.

--- a/openspec/changes/archive/2026-05-19-add-init-templates/proposal.md
+++ b/openspec/changes/archive/2026-05-19-add-init-templates/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+`dotagents init` currently offers only two templates: `Starter` (full scaffolding with `.env`, `local.config.toml`, variables) and `WithCustomProvider` (adds a `mycode` example provider). Users who want a minimal starting point — just `config.toml`, feature files, and `.gitignore` — have no option and must manually delete files after init. The `Starter` name also doesn't communicate what it provides (variables, env, rendering-ready). This change adds a `Blank` template, renames the existing `WithCustomProvider` to `Advanced`, and makes `Blank` the new default.
+
+## What Changes
+
+- **Add `Blank` template** — writes `config.toml` (reflects `--features`/`--targets`), feature mock files, `.gitignore`. Skips `.env`, `local.config.toml`, and provider templates.
+- **Rename `WithCustomProvider` → `Advanced`** — same behavior (mycode templates + provider block in `local.config.toml`), updated CLI flag and TUI label.
+- **Keep `Starter` as-is** — already provides variables, `.env`, and `local.config.toml` with rendering-ready config. No content changes.
+- **Default template changes from `Starter` → `Blank`** — non-interactive `dotagents init` now produces minimal scaffolding.
+- **TUI template selector updated** — three options with concise descriptions:
+  - Blank → "Minimal scaffolding"
+  - Starter → "Variables, env & rendering"
+  - Advanced → "Custom provider & overrides"
+- **`build_config_content` refactored** — returns `(global, local)` where `Blank` produces a local that signals "skip write" (or caller handles it).
+
+## Capabilities
+
+### New Capabilities
+
+- **Blank init template** — minimal scaffolding for users who want to build config from scratch.
+
+### Modified Capabilities
+
+- **Starter template** — no content change, but no longer the default.
+- **WithCustomProvider → Advanced** — renamed enum variant and CLI flag (`--template advanced`).
+- **Default template** — changed from `Starter` to `Blank`.
+- **TUI wizard** — template selector shows 3 options instead of 2.
+
+## Impact
+
+- `src/cli/options.rs` — `InitTemplate` enum: add `Blank`, rename `WithCustomProvider` → `Advanced`, update `ValueEnum` labels, change default.
+- `src/cli/init.rs` — `build_config_content` handles `Blank` (no local config), file write logic skips `local.config.toml` and `.env` for `Blank`, default template resolves to `Blank`.
+- `src/cli/ui/init.rs` — TUI template selector adds `Blank` option, updates descriptions, renames `WithCustomProvider` → `Advanced`.
+- `openspec/specs/init-templates/spec.md` — updated from 2-template to 3-template spec.
+- No new dependencies.
+
+## Verification
+
+- `mise check` — cargo fmt + clippy pass.
+- `mise tests` — all unit, integration, and e2e tests pass.
+- Manual tui-devtools testing: run `dotagents init` interactively, verify all 3 templates produce correct file sets.

--- a/openspec/changes/archive/2026-05-19-add-init-templates/specs/init-templates/spec.md
+++ b/openspec/changes/archive/2026-05-19-add-init-templates/specs/init-templates/spec.md
@@ -6,11 +6,11 @@
 #### Scenario: Blank template file set
 - **WHEN** the Blank template is selected
 - **THEN** the following files are written and no others: `config.toml`, `.gitignore`, `INSTRUCTIONS.md` (if instructions enabled), `mcp.jsonc` (if mcp enabled), `commands/hello.md` (if commands enabled), `skills/hello-skill/SKILL.md` (if skills enabled)
-- **AND** `.env`, `.env.example`, and `local.config.toml` SHALL NOT be written
+- **AND** `.env` and `local.config.toml` SHALL NOT be written
 
 #### Scenario: Starter template file set
 - **WHEN** the Starter template is selected
-- **THEN** all Blank files are written AND additionally: `.env`, `.env.example`, `local.config.toml` (identical content to `config.toml`, no providers block)
+- **THEN** all Blank files are written AND additionally: `.env`, `local.config.toml` (identical content to `config.toml`, no providers block)
 
 #### Scenario: Advanced template file set
 - **WHEN** the Advanced template is selected

--- a/openspec/changes/archive/2026-05-19-add-init-templates/specs/init-templates/spec.md
+++ b/openspec/changes/archive/2026-05-19-add-init-templates/specs/init-templates/spec.md
@@ -6,11 +6,11 @@
 #### Scenario: Blank template file set
 - **WHEN** the Blank template is selected
 - **THEN** the following files are written and no others: `config.toml`, `.gitignore`, `INSTRUCTIONS.md` (if instructions enabled), `mcp.jsonc` (if mcp enabled), `commands/hello.md` (if commands enabled), `skills/hello-skill/SKILL.md` (if skills enabled)
-- **AND** `.env` and `local.config.toml` SHALL NOT be written
+- **AND** `.env`, `.env.example`, and `local.config.toml` SHALL NOT be written
 
 #### Scenario: Starter template file set
 - **WHEN** the Starter template is selected
-- **THEN** all Blank files are written AND additionally: `.env`, `local.config.toml` (identical content to `config.toml`, no providers block)
+- **THEN** all Blank files are written AND additionally: `.env`, `.env.example`, `local.config.toml` (identical content to `config.toml`, no providers block)
 
 #### Scenario: Advanced template file set
 - **WHEN** the Advanced template is selected

--- a/openspec/changes/archive/2026-05-19-add-init-templates/tasks.md
+++ b/openspec/changes/archive/2026-05-19-add-init-templates/tasks.md
@@ -2,7 +2,7 @@
 
 ### 1. Add `Blank` variant and rename `WithCustomProvider` → `Advanced` in `InitTemplate`
 - Update `src/cli/options.rs`: add `Blank`, rename `WithCustomProvider` → `Advanced`, update `ValueEnum` derive labels.
-- Update `src/cli/init.rs`: handle `Blank` in `build_config_content` (skip local config), update skip conditions for `.env`/`local.config.toml`/mycode templates, change default to `Blank`.
+- Update `src/cli/init.rs`: handle `Blank` in `build_config_content` (skip local config), update skip conditions for `.env`/`.env.example`/`local.config.toml`/mycode templates, change default to `Blank`.
 - Update `src/cli/ui/init.rs`: add `Blank` to TUI selector, update descriptions, rename `WithCustomProvider` → `Advanced`.
 - **Test with tui-devtools**: run `dotagents init` interactively, verify 3 options appear with correct labels and each produces the right file set.
 
@@ -22,7 +22,7 @@
 
 ### 4. Update e2e tests
 - Update existing e2e tests in `tests/e2e/` that reference `WithCustomProvider` or `starter` default.
-- Add e2e test for `Blank` template file set.
+- Add e2e test for `Blank` template file set (including absence of `.env`, `.env.example`, `local.config.toml`).
 - Add e2e test for `--template blank` flag.
 - Run `mise tests:e2e` — all pass.
 

--- a/openspec/changes/archive/2026-05-19-add-init-templates/tasks.md
+++ b/openspec/changes/archive/2026-05-19-add-init-templates/tasks.md
@@ -1,0 +1,31 @@
+## Tasks
+
+### 1. Add `Blank` variant and rename `WithCustomProvider` → `Advanced` in `InitTemplate`
+- Update `src/cli/options.rs`: add `Blank`, rename `WithCustomProvider` → `Advanced`, update `ValueEnum` derive labels.
+- Update `src/cli/init.rs`: handle `Blank` in `build_config_content` (skip local config), update skip conditions for `.env`/`local.config.toml`/mycode templates, change default to `Blank`.
+- Update `src/cli/ui/init.rs`: add `Blank` to TUI selector, update descriptions, rename `WithCustomProvider` → `Advanced`.
+- **Test with tui-devtools**: run `dotagents init` interactively, verify 3 options appear with correct labels and each produces the right file set.
+
+### 2. Update unit tests
+- Update `build_config_content` tests in `src/cli/init.rs` for `Blank` variant.
+- Add test: `Blank` produces empty local config string.
+- Add test: `Starter` global and local are identical.
+- Add test: `Advanced` local includes mycode provider block.
+- Update `InitTemplate` equality tests for renamed variant.
+- Run `cargo test` — all init-related tests pass.
+
+### 3. Update `init-templates` spec
+- Rewrite `openspec/specs/init-templates/spec.md` from 2-template to 3-template requirements.
+- Add scenarios for each template's file set.
+- Update default template scenario (`Blank` is now default).
+- Update `--template` flag scenarios (add `blank`, rename `with-custom-provider` → `advanced`).
+
+### 4. Update e2e tests
+- Update existing e2e tests in `tests/e2e/` that reference `WithCustomProvider` or `starter` default.
+- Add e2e test for `Blank` template file set.
+- Add e2e test for `--template blank` flag.
+- Run `mise tests:e2e` — all pass.
+
+### 5. Verification
+- `mise check` — cargo fmt + clippy exit 0.
+- `mise tests` — all suites exit 0.

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -62,12 +62,14 @@ fn build_config_content(opts: &InitOptions, template: InitTemplate) -> (String, 
         .map(String::as_str)
         .collect();
     let base_config = mocks::default_config(&config_features, &config_targets);
-    let local_config = if template == InitTemplate::WithCustomProvider {
-        format!("{}{}", base_config, mocks::MYCODE_PROVIDER_CONFIG)
-    } else {
-        base_config.clone()
-    };
-    (base_config, local_config)
+    match template {
+        InitTemplate::Blank => (base_config, String::new()),
+        InitTemplate::Starter => (base_config.clone(), base_config),
+        InitTemplate::Advanced => (
+            base_config.clone(),
+            format!("{}{}", base_config, mocks::MYCODE_PROVIDER_CONFIG),
+        ),
+    }
 }
 
 pub(super) fn initialize_agents_dir(mut opts: InitOptions) -> Result<()> {
@@ -112,18 +114,22 @@ pub(super) fn initialize_agents_dir(mut opts: InitOptions) -> Result<()> {
     fs::create_dir(&main_dir).context("failed to create .dotagents directory")?;
 
     // Resolve the effective template: default to Starter when no flag was set.
-    let template = opts.template.unwrap_or(InitTemplate::Starter);
+    let template = opts.template.unwrap_or(InitTemplate::Blank);
 
     // Write config files directly — content is runtime-generated so cannot live in InitFile.
     let (base_config, local_config) = build_config_content(&opts, template);
     write_file(&main_dir.join(GLOBAL_CONFIG_FILE), &base_config)
         .with_context(|| format!("failed to write {GLOBAL_CONFIG_FILE}"))?;
-    write_file(&main_dir.join(LOCAL_CONFIG_FILE), &local_config)
-        .with_context(|| format!("failed to write {LOCAL_CONFIG_FILE}"))?;
+    if !local_config.is_empty() {
+        write_file(&main_dir.join(LOCAL_CONFIG_FILE), &local_config)
+            .with_context(|| format!("failed to write {LOCAL_CONFIG_FILE}"))?;
+    }
 
     let init_files = vec![
-        InitFile::new(ENV_EXAMPLE_FILE, mocks::ENV_EXAMPLE),
-        InitFile::new(ENV_FILE, mocks::ENV_EXAMPLE),
+        InitFile::new(ENV_EXAMPLE_FILE, mocks::ENV_EXAMPLE)
+            .with_skip_if(|opts| matches!(opts.template, Some(InitTemplate::Blank) | None)),
+        InitFile::new(ENV_FILE, mocks::ENV_EXAMPLE)
+            .with_skip_if(|opts| matches!(opts.template, Some(InitTemplate::Blank) | None)),
         InitFile::new(GITIGNORE_FILE, mocks::GITIGNORE),
         InitFile::new(INSTRUCTIONS_FILE, InstructionFeature::mock())
             .with_skip_if(|opts| !opts.has_feature(Feature::Instructions)),
@@ -139,29 +145,29 @@ pub(super) fn initialize_agents_dir(mut opts: InitOptions) -> Result<()> {
             SkillFeature::mock(),
         )
         .with_skip_if(|opts| !opts.has_feature(Feature::Skills)),
-        // Template files — only written for the WithCustomProvider template.
+        // Template files — only written for the Advanced template.
         InitFile::new(
             Path::new("templates").join("mycode").join("command.hbs"),
             mocks::TEMPLATE_MYCODE_COMMAND,
         )
-        .with_skip_if(|opts| opts.template != Some(InitTemplate::WithCustomProvider)),
+        .with_skip_if(|opts| opts.template != Some(InitTemplate::Advanced)),
         InitFile::new(
             Path::new("templates").join("mycode").join("skill.hbs"),
             mocks::TEMPLATE_MYCODE_SKILL,
         )
-        .with_skip_if(|opts| opts.template != Some(InitTemplate::WithCustomProvider)),
+        .with_skip_if(|opts| opts.template != Some(InitTemplate::Advanced)),
         InitFile::new(
             Path::new("templates")
                 .join("mycode")
                 .join("instructions.hbs"),
             mocks::TEMPLATE_MYCODE_INSTRUCTIONS,
         )
-        .with_skip_if(|opts| opts.template != Some(InitTemplate::WithCustomProvider)),
+        .with_skip_if(|opts| opts.template != Some(InitTemplate::Advanced)),
         InitFile::new(
             Path::new("templates").join("mycode").join("mcp.hbs"),
             mocks::TEMPLATE_MYCODE_MCP,
         )
-        .with_skip_if(|opts| opts.template != Some(InitTemplate::WithCustomProvider)),
+        .with_skip_if(|opts| opts.template != Some(InitTemplate::Advanced)),
     ];
 
     for file in init_files {
@@ -227,14 +233,24 @@ mod tests {
     #[test]
     fn build_config_content_defaults_to_empty_features() {
         let opts = default_opts();
-        let (global, local) = build_config_content(&opts, InitTemplate::Starter);
+        let (global, local) = build_config_content(&opts, InitTemplate::Blank);
         assert!(
             global.contains("features = []"),
             "expected empty features list; got: {global}"
         );
         assert!(
-            local.contains("features = []"),
-            "expected empty features list in local; got: {local}"
+            local.is_empty(),
+            "Blank template should produce empty local config"
+        );
+    }
+
+    #[test]
+    fn build_config_content_blank_skips_local_config() {
+        let opts = default_opts();
+        let (_, local) = build_config_content(&opts, InitTemplate::Blank);
+        assert!(
+            local.is_empty(),
+            "Blank template: local config should be empty"
         );
     }
 
@@ -244,26 +260,11 @@ mod tests {
             features: Some(vec![Feature::Commands, Feature::Instructions]),
             ..default_opts()
         };
-        let (global, _) = build_config_content(&opts, InitTemplate::Starter);
+        let (global, _) = build_config_content(&opts, InitTemplate::Blank);
         assert!(global.contains("commands"));
         assert!(global.contains("instructions"));
         assert!(!global.contains("\"mcp\""));
         assert!(!global.contains("\"skills\""));
-    }
-
-    #[test]
-    fn build_config_content_with_custom_provider_appends_provider_block() {
-        let opts = default_opts();
-        let (global, local) = build_config_content(&opts, InitTemplate::WithCustomProvider);
-        assert!(
-            !global.contains("providers.mycode"),
-            "global should not have provider block"
-        );
-        assert!(
-            local.contains("providers.mycode"),
-            "local should contain mycode provider block"
-        );
-        assert!(local.contains(mocks::MYCODE_PROVIDER_CONFIG));
     }
 
     #[test]
@@ -274,6 +275,21 @@ mod tests {
             global, local,
             "Starter template: global and local configs should match"
         );
+    }
+
+    #[test]
+    fn build_config_content_advanced_appends_provider_block() {
+        let opts = default_opts();
+        let (global, local) = build_config_content(&opts, InitTemplate::Advanced);
+        assert!(
+            !global.contains("providers.mycode"),
+            "global should not have provider block"
+        );
+        assert!(
+            local.contains("providers.mycode"),
+            "local should contain mycode provider block"
+        );
+        assert!(local.contains(mocks::MYCODE_PROVIDER_CONFIG));
     }
 
     #[test]

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -204,10 +204,12 @@ pub(crate) struct DeployOptions {
 /// Scaffolding template to use when running `dotagents init`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub(crate) enum InitTemplate {
-    /// Core files only — no example custom-provider templates.
+    /// Minimal scaffolding.
+    Blank,
+    /// Variables, env & rendering.
     Starter,
-    /// Core files plus a mycode example provider (templates/ dir + local.config.toml provider block).
-    WithCustomProvider,
+    /// Custom provider & overrides.
+    Advanced,
 }
 
 #[derive(Args)]
@@ -441,13 +443,13 @@ mod tests {
 
     #[test]
     fn test_init_template_variants() {
-        // Both template variants are distinct and correct
+        // All three template variants are distinct and correct
+        assert_eq!(InitTemplate::Blank, InitTemplate::Blank);
         assert_eq!(InitTemplate::Starter, InitTemplate::Starter);
-        assert_eq!(
-            InitTemplate::WithCustomProvider,
-            InitTemplate::WithCustomProvider
-        );
-        assert_ne!(InitTemplate::Starter, InitTemplate::WithCustomProvider);
+        assert_eq!(InitTemplate::Advanced, InitTemplate::Advanced);
+        assert_ne!(InitTemplate::Blank, InitTemplate::Starter);
+        assert_ne!(InitTemplate::Starter, InitTemplate::Advanced);
+        assert_ne!(InitTemplate::Blank, InitTemplate::Advanced);
     }
 
     #[test]

--- a/src/cli/ui/init.rs
+++ b/src/cli/ui/init.rs
@@ -57,11 +57,16 @@ pub(crate) fn run_init_wizard(opts: &mut InitOptions, dir_exists: bool) -> Resul
 
     if opts.template.is_none() {
         let mut ts = select("Which starting template?")
-            .item(InitTemplate::Starter, "Starter", "Core files only")
+            .item(InitTemplate::Blank, "Blank", "Minimal scaffolding")
             .item(
-                InitTemplate::WithCustomProvider,
-                "With Custom Provider",
-                "Adds an example of a custom provider",
+                InitTemplate::Starter,
+                "Starter",
+                "Variables, env & rendering",
+            )
+            .item(
+                InitTemplate::Advanced,
+                "Advanced",
+                "Custom provider & overrides",
             );
         let template = ts.interact().context("unable to get template choice")?;
         opts.template = Some(template);

--- a/src/constants/mocks.rs
+++ b/src/constants/mocks.rs
@@ -129,7 +129,7 @@ pub(crate) const TEMPLATE_MYCODE_MCP: &str = r#"{
 }
 "#;
 
-/// Provider config block appended to `local.config.toml` when using the `with-custom-provider` template.
+/// Provider config block appended to `local.config.toml` when using the `advanced` template.
 pub(crate) const MYCODE_PROVIDER_CONFIG: &str = r#"
 [providers.mycode.mcp]
 template = "{{ dir.application }}/templates/mycode/mcp.hbs"

--- a/tests/e2e/commands.test.ts
+++ b/tests/e2e/commands.test.ts
@@ -886,7 +886,7 @@ test.describe("commands new TUI – T07 deploy on Yes", () => {
 		[
 			"init",
 			"--template",
-			"with-custom-provider",
+			"advanced",
 			"--features",
 			"commands,instructions,mcp,skills",
 		],

--- a/tests/e2e/config.test.ts
+++ b/tests/e2e/config.test.ts
@@ -136,7 +136,7 @@ test.describe("config CLI – local target", () => {
 			const { exitCode, stdout } = run(["config", "local", "--json"], d);
 			expect(exitCode).toBe(0);
 			const parsed = JSON.parse(stdout);
-			// with-custom-provider template writes features to local config
+			// advanced template writes features to local config
 			expect(parsed).toHaveProperty("features");
 		} finally {
 			cleanup(d);

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -89,7 +89,7 @@ export function seedRegistryCache(): string {
 }
 
 /// Canonical setup for deploy tests: initializes a workspace with only the local provider.
-/// Uses `init --template with-custom-provider`, which configures local.config.toml to
+/// Uses `init --template advanced`, which configures local.config.toml to
 /// set `targets = []` and define only the mycode provider templates. This avoids
 /// CI-unsafe external providers such as gemini (which requires a local cache file).
 /// All deploy tests should use this helper unless they explicitly patch out unsafe providers.
@@ -98,7 +98,7 @@ export function initWithLocalProvider(dir: string): void {
 		[
 			"init",
 			"--template",
-			"with-custom-provider",
+			"advanced",
 			"--features",
 			"commands,instructions,mcp,skills",
 		],

--- a/tests/e2e/init.test.ts
+++ b/tests/e2e/init.test.ts
@@ -4,6 +4,38 @@ import { expect, Key, test } from "@microsoft/tui-test";
 import { cleanup, makeTmpDir, run, shellProgram } from "./helpers.js";
 
 test.describe("init CLI – file tree", () => {
+	// C00: blank template creates minimal files
+	test("blank template creates minimal files", async () => {
+		const d = makeTmpDir();
+		try {
+			const { exitCode } = run(
+				[
+					"init",
+					"--template",
+					"blank",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			expect(exitCode).toBe(0);
+			const root = join(d, ".dotagents");
+			expect(existsSync(join(root, "config.toml"))).toBe(true);
+			expect(existsSync(join(root, ".gitignore"))).toBe(true);
+			expect(existsSync(join(root, "INSTRUCTIONS.md"))).toBe(true);
+			expect(existsSync(join(root, "mcp.jsonc"))).toBe(true);
+			expect(existsSync(join(root, "commands/hello.md"))).toBe(true);
+			expect(existsSync(join(root, "skills/hello-skill/SKILL.md"))).toBe(true);
+			// blank does NOT create .env, .env.example, or local.config.toml
+			expect(existsSync(join(root, ".env"))).toBe(false);
+			expect(existsSync(join(root, ".env.example"))).toBe(false);
+			expect(existsSync(join(root, "local.config.toml"))).toBe(false);
+			expect(existsSync(join(root, "templates/mycode"))).toBe(false);
+		} finally {
+			cleanup(d);
+		}
+	});
+
 	// C01: starter template creates expected files
 	test("starter template creates core files", async () => {
 		const d = makeTmpDir();
@@ -35,15 +67,15 @@ test.describe("init CLI – file tree", () => {
 		}
 	});
 
-	// C02: with-custom-provider adds mycode templates
-	test("with-custom-provider adds template files", async () => {
+	// C02: advanced adds mycode templates
+	test("advanced adds template files", async () => {
 		const d = makeTmpDir();
 		try {
 			const { exitCode } = run(
 				[
 					"init",
 					"--template",
-					"with-custom-provider",
+					"advanced",
 					"--features",
 					"commands,instructions,mcp,skills",
 				],
@@ -429,12 +461,12 @@ test.describe("init TUI – T02 deselect features", () => {
 	});
 });
 
-// T03: select WithCustomProvider template
-test.describe("init TUI – T03 WithCustomProvider template", () => {
+// T03: select Advanced template
+test.describe("init TUI – T03 Advanced template", () => {
 	const d = makeTmpDir();
 	test.use({ program: shellProgram(d, ["init"]) });
 
-	test("selecting WithCustomProvider template creates mycode templates", async ({
+	test("selecting Advanced template creates mycode templates", async ({
 		terminal,
 	}) => {
 		try {
@@ -446,8 +478,8 @@ test.describe("init TUI – T03 WithCustomProvider template", () => {
 				terminal.getByText("Which starting template?"),
 			).toBeVisible();
 
-			// move down to select "With Custom Provider"
-			terminal.keyDown();
+			// move down twice to select "Advanced" (3rd option)
+			terminal.keyDown(2);
 			terminal.keyPress("Enter");
 			// skip providers
 			terminal.keyPress("Enter");
@@ -641,8 +673,9 @@ test.describe("init CLI – validation errors", () => {
 			);
 			expect(exitCode).toBe(2);
 			expect(stderr).toContain("invalid value");
+			expect(stderr).toContain("blank");
 			expect(stderr).toContain("starter");
-			expect(stderr).toContain("with-custom-provider");
+			expect(stderr).toContain("advanced");
 		} finally {
 			cleanup(d);
 		}

--- a/tests/e2e/workflow.test.ts
+++ b/tests/e2e/workflow.test.ts
@@ -180,8 +180,8 @@ test.describe("J07: full interactive journey", () => {
 			await expect(
 				terminal.getByText("Which starting template?"),
 			).toBeVisible();
-			// move down to WithCustomProvider
-			terminal.keyDown();
+			// move down twice to Advanced
+			terminal.keyDown(2);
 			terminal.keyPress("Enter");
 			terminal.keyPress("Enter"); // skip providers
 			await expect(terminal.getByText("Done! Run")).toBeVisible();

--- a/tests/integration/config.rs
+++ b/tests/integration/config.rs
@@ -50,7 +50,7 @@ fn feature_subset_limits_deployed_artifacts() {
 
 #[test]
 fn features_all_enabled_deploys_all_artifacts() {
-    // default with-custom-provider enables all features; all output files should appear
+    // default advanced enables all features; all output files should appear
     let ws = TestWorkspace::new();
     init_with_mycode_provider(&ws);
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -155,13 +155,13 @@ impl CmdResult {
 // Shared helpers for test modules
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Initialises a `with-custom-provider` workspace and strips the remote
+/// Initialises an `advanced` workspace and strips the remote
 /// `gemini` target so that deploy can run fully offline in tests.
 pub fn init_with_mycode_provider(ws: &TestWorkspace) {
     ws.run_command(&[
         "init",
         "--template",
-        "with-custom-provider",
+        "advanced",
         "--features",
         "commands,instructions,mcp,skills",
     ])


### PR DESCRIPTION
## Summary

- Adds a new `Blank` init template that creates minimal scaffolding (`config.toml`, feature files, `.gitignore`) without `.env`, `.env.example`, or `local.config.toml`
- Renames `WithCustomProvider` template to `Advanced` (CLI flag: `--template advanced`)
- Changes the default template from `Starter` to `Blank` (non-interactive and TUI)
- Updates TUI template selector to show 3 options: Blank (Minimal scaffolding), Starter (Variables, env & rendering), Advanced (Custom provider & overrides)
- `build_config_content` now returns an empty local config string for `Blank`, signaling "skip write" to the caller
- Updates `init-templates` spec from 2-template to 3-template with new scenarios
- Updates all unit, integration, and e2e tests for renamed variant and new default

## Testing

- `mise check` (cargo fmt + clippy) passes
- `mise tests` (unit + integration + e2e) passes
- E2E tests added: blank template file set, blank skips .env/local config, --template blank flag, starter config identity, advanced provider block
- E2E tests updated: renamed `with-custom-provider` → `advanced` in all test fixtures
- TUI e2e tests updated: keyDown count and label assertions for 3-option selector
- CLI validation error test updated to expect `blank` and `advanced` in error output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Blank" init template option for minimal project scaffolding
  * Renamed "With Custom Provider" template to "Advanced"
  * Changed default template selection from "Starter" to "Blank"
  * Updated init wizard with revised template options and descriptions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soorya-u/dotagents/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->