### PR TITLE
feat: extend SkillMetadata with disable-model-invocation, user-invocable, and paths; render metadata in all provider templates

### DIFF
--- a/openspec/changes/archive/2026-05-21-extend-skill-metadata/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-21-extend-skill-metadata/.openspec.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/openspec/changes/archive/2026-05-21-extend-skill-metadata/design.md
+++ b/openspec/changes/archive/2026-05-21-extend-skill-metadata/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The `SkillMetadata` struct currently has 6 fields matching the Agent Skills spec: `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`. Two gaps exist:
+
+1. **`metadata` not rendered** — the struct has `Option<HashMap<String, String>>` but no `skill.hbs` template outputs it via `{{#each skill.metadata}}`
+2. **Claude Code extensions missing** — `disable-model-invocation`, `user-invocable`, and `paths` are documented in [Claude Code's skill frontmatter reference](https://code.claude.com/docs/en/skills#frontmatter-reference) but not in our struct
+
+The `allowed_tools` type was questioned in the issue but the Agent Skills spec confirms it should remain a space-separated `Option<String>`. No type change needed.
+
+Amp's `globs` field was also mentioned but it is an AGENTS.md instruction-file feature, not a skill frontmatter field — out of scope.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `disable_model_invocation: Option<bool>` with `#[serde(rename = "disable-model-invocation")]`
+- Add `user_invocable: Option<bool>` with `#[serde(rename = "user-invocable")]`
+- Add `paths: Option<Vec<String>>`
+- Render `metadata` in all 20 provider templates
+- Render new fields in the specific provider templates that use them
+- Update scaffold function to accept new optional fields
+- Update tests
+
+**Non-Goals:**
+
+- Changing `allowed_tools` type (spec says space-separated string)
+- Adding `globs` (not a skill frontmatter field)
+- Adding other Claude Code extensions not in scope (`when_to_use`, `argument-hint`, `arguments`, `model`, `effort`, `context`, `agent`, `hooks`, `shell`) — these can be future PRs
+
+## Decisions
+
+### 1. New fields on `SkillMetadata`
+
+Add three fields, all `Option<>` with `skip_serializing_if = "Option::is_none"`:
+
+```rust
+#[serde(rename = "disable-model-invocation", skip_serializing_if = "Option::is_none")]
+pub disable_model_invocation: Option<bool>,
+
+#[serde(rename = "user-invocable", skip_serializing_if = "Option::is_none")]
+pub user_invocable: Option<bool>,
+
+#[serde(skip_serializing_if = "Option::is_none")]
+pub paths: Option<Vec<String>>,
+```
+
+`paths` uses `Vec<String>` because the spec says it accepts "a comma-separated string or a YAML list" — storing as `Vec<String>` lets us output as a YAML list in templates.
+
+### 2. Template rendering strategy
+
+**`metadata` — all 20 providers.** Pattern:
+```handlebars
+{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}
+```
+
+**`disable-model-invocation` — 4 providers** (Claude, Cursor, Factory Droid, Pi):
+```handlebars
+{{#if skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
+{{/if}}
+```
+
+**`user-invocable` — 3 providers** (Claude, Factory Droid, Mistral Vibe):
+```handlebars
+{{#if skill.user-invocable}}user-invocable: {{skill.user-invocable}}
+{{/if}}
+```
+
+**`paths` — 1 provider** (Claude):
+```handlebars
+{{#if skill.paths}}paths:
+{{#each skill.paths}}  - {{this}}
+{{/each}}
+{{/if}}
+```
+
+### 3. Template field ordering
+
+New fields are inserted in a consistent order after existing fields: `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `paths`. This matches the logical grouping from the spec and Claude docs.
+
+### 4. `to_value` update
+
+The `to_value` impl serializes `SkillMetadata` via `serde_json::to_value`, so new fields automatically appear in the Handlebars context. No code change needed beyond adding the struct fields.
+
+### 5. Scaffold update
+
+`SkillFeature::scaffold()` gains two new parameters (`disable_model_invocation: bool`, `user_invocable: bool`) defaulting to `None` in the struct. The CLI scaffold call passes `None` for both — interactive TUI can set them later.
+
+## Risks / Trade-offs
+
+- **Template churn across 20 files** — mechanical change but high surface area. Each template must be verified individually.
+- **`paths` as `Vec<String>` vs `String`** — spec says "comma-separated string or YAML list". We store as `Vec<String>` and render as YAML list. If a provider needs comma-separated, the template can use `{{join skill.paths ","}}` but Handlebars doesn't have a built-in join. If needed later, we can add a custom helper.
+- **Breaking existing deployed skills** — additive only, existing skills without new fields deploy unchanged (fields are `None`, templates skip them).
+
+## Migration Plan
+
+Additive feature — no migration needed. Existing skill files without the new fields parse fine (fields default to `None`). Existing deployed outputs are unaffected.
+
+## Open Questions
+
+- None

--- a/openspec/changes/archive/2026-05-21-extend-skill-metadata/proposal.md
+++ b/openspec/changes/archive/2026-05-21-extend-skill-metadata/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`SkillMetadata` is missing several fields that providers actively use. The [Agent Skills specification](https://agentskills.io/specification) defines the core schema, and Claude Code extends it with invocation-control fields. These all share the same solution space — extending `SkillMetadata` with optional fields and fixing template rendering for existing ones. Resolves [gh#138](https://github.com/soorya-u/dotagents/issues/138).
+
+## What Changes
+
+- Add `disable-model-invocation` (`Option<bool>`) and `user-invocable` (`Option<bool>`) to `SkillMetadata` — Claude Code extensions for controlling skill activation
+- Add `paths` (`Option<Vec<String>>`) to `SkillMetadata` — Claude Code field for file-gated auto-activation
+- Render `metadata` field in all 20 provider `skill.hbs` templates (struct field exists but no template outputs it)
+- Render the new fields in the provider templates that support them
+
+## Capabilities
+
+### New Capabilities
+
+- None
+
+### Modified Capabilities
+
+- `skill-feature`: `SkillMetadata` gains three new optional fields (`disable-model-invocation`, `user-invocable`, `paths`). All 20 provider `skill.hbs` templates gain `metadata` rendering. Four templates gain `disable-model-invocation`, three gain `user-invocable`, one gains `paths`.
+
+## Impact
+
+- Modified: `src/core/features/skill.rs` — add 3 fields to `SkillMetadata`, update `to_value`, scaffold, tests
+- Modified: 20 `public/v1/templates/*/skill.hbs` files — add `metadata` rendering to all, new fields to specific providers
+- No breaking changes — all new fields are `Option<>` and omitted when `None`

--- a/openspec/changes/archive/2026-05-21-extend-skill-metadata/specs/skill-feature/spec.md
+++ b/openspec/changes/archive/2026-05-21-extend-skill-metadata/specs/skill-feature/spec.md
@@ -98,7 +98,7 @@ The system SHALL support Claude Code's skill frontmatter extensions: `disable-mo
 
 #### Scenario: Parse paths as list
 - **WHEN** a skill file has `paths: ["src/**/*.rs", "tests/**"]` in frontmatter
-- **THEN** the system SHALL parse it as `Some(vec!["src/**/*.rs".to_string(), "tests/**.to_string()])` on `SkillMetadata.paths`
+- **THEN** the system SHALL parse it as `Some(vec!["src/**/*.rs".to_string(), "tests/**".to_string()])` on `SkillMetadata.paths`
 
 #### Scenario: Deploy disable-model-invocation to claude
 - **WHEN** a skill with `disable-model-invocation: true` is deployed to the claude provider

--- a/openspec/changes/archive/2026-05-21-extend-skill-metadata/tasks.md
+++ b/openspec/changes/archive/2026-05-21-extend-skill-metadata/tasks.md
@@ -1,0 +1,43 @@
+## 1. Extend SkillMetadata struct
+
+- [x] 1.1 Add `disable_model_invocation: Option<bool>` with `#[serde(rename = "disable-model-invocation", skip_serializing_if = "Option::is_none")]` to `SkillMetadata`
+- [x] 1.2 Add `user_invocable: Option<bool>` with `#[serde(rename = "user-invocable", skip_serializing_if = "Option::is_none")]` to `SkillMetadata`
+- [x] 1.3 Add `paths: Option<Vec<String>>` with `#[serde(skip_serializing_if = "Option::is_none")]` to `SkillMetadata`
+- [x] 1.4 Update `scaffold()` to accept `disable_model_invocation` and `user_invocable` optional bool parameters
+- [x] 1.5 Update `to_value` test to include new fields when present
+- [x] 1.6 Add unit tests: parse new fields, serialize omits absent, roundtrip preserves, `to_value` includes new fields
+- [x] 1.7 Test with tui-devtools: create a skill with new fields, verify `skills ls --content` shows them
+
+## 2. Render metadata in all 20 provider templates
+
+- [x] 2.1 Add `metadata` rendering block to all 20 `skill.hbs` templates (after `compatibility`, before provider-specific fields)
+- [x] 2.2 Templates: amp, autohand, auggie, claude, cline, codex, copilot, cursor, deepagents, factory-droid, gemini, goose, junie, kilocode, kimi, mistral-vibe, opencode, pi, qoder-cli, qwen
+- [x] 2.3 Test with tui-devtools: deploy a skill with `metadata: {author: test, version: "1.0"}` to multiple providers, verify output
+
+## 3. Render disable-model-invocation in 4 provider templates
+
+- [x] 3.1 Add `disable-model-invocation` rendering to claude/skill.hbs
+- [x] 3.2 Add `disable-model-invocation` rendering to cursor/skill.hbs
+- [x] 3.3 Add `disable-model-invocation` rendering to factory-droid/skill.hbs
+- [x] 3.4 Add `disable-model-invocation` rendering to pi/skill.hbs
+- [x] 3.5 Test with tui-devtools: deploy skill with `disable-model-invocation: true` to each provider
+
+## 4. Render user-invocable in 3 provider templates
+
+- [x] 4.1 Add `user-invocable` rendering to claude/skill.hbs
+- [x] 4.2 Add `user-invocable` rendering to factory-droid/skill.hbs
+- [x] 4.3 Add `user-invocable` rendering to mistral-vibe/skill.hbs
+- [x] 4.4 Test with tui-devtools: deploy skill with `user-invocable: false` to each provider
+
+## 5. Render paths in claude template
+
+- [x] 5.1 Add `paths` rendering to claude/skill.hbs
+- [x] 5.2 Test with tui-devtools: deploy skill with `paths: ["src/**/*.rs", "tests/**"]` to claude provider
+
+## 6. Update spec and verify
+
+- [x] 6.1 Update `openspec/specs/skill-feature/spec.md` with new requirements for the 3 fields and metadata rendering
+- [x] 6.2 Run `mise check` — cargo fmt + cargo clippy must exit 0
+- [x] 6.3 Run `mise tests` — all unit + integration + e2e tests must pass
+- [x] 6.4 Add unit tests for new struct fields in `src/core/features/skill.rs`
+- [x] 6.5 Add e2e tests in `tests/e2e/skills.test.ts` for new fields in deployed output

--- a/openspec/specs/skill-feature/spec.md
+++ b/openspec/specs/skill-feature/spec.md
@@ -98,7 +98,7 @@ The system SHALL support Claude Code's skill frontmatter extensions: `disable-mo
 
 #### Scenario: Parse paths as list
 - **WHEN** a skill file has `paths: ["src/**/*.rs", "tests/**"]` in frontmatter
-- **THEN** the system SHALL parse it as `Some(vec!["src/**/*.rs".to_string(), "tests/**.to_string()])` on `SkillMetadata.paths`
+- **THEN** the system SHALL parse it as `Some(vec!["src/**/*.rs".to_string(), "tests/**".to_string()])` on `SkillMetadata.paths`
 
 #### Scenario: Deploy disable-model-invocation to claude
 - **WHEN** a skill with `disable-model-invocation: true` is deployed to the claude provider

--- a/public/v1/templates/amp/skill.hbs
+++ b/public/v1/templates/amp/skill.hbs
@@ -1,6 +1,9 @@
 ---
 name: {{json skill.name}}
 description: {{json skill.description}}
----
+{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/amp/skill.hbs
+++ b/public/v1/templates/amp/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/amp/skill.hbs
+++ b/public/v1/templates/amp/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/auggie/skill.hbs
+++ b/public/v1/templates/auggie/skill.hbs
@@ -1,6 +1,9 @@
 ---
 name: {{json skill.name}}
 description: {{json skill.description}}
----
+{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/auggie/skill.hbs
+++ b/public/v1/templates/auggie/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/auggie/skill.hbs
+++ b/public/v1/templates/auggie/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/autohand/skill.hbs
+++ b/public/v1/templates/autohand/skill.hbs
@@ -2,6 +2,9 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/autohand/skill.hbs
+++ b/public/v1/templates/autohand/skill.hbs
@@ -3,7 +3,7 @@ name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/autohand/skill.hbs
+++ b/public/v1/templates/autohand/skill.hbs
@@ -3,7 +3,7 @@ name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/claude/skill.hbs
+++ b/public/v1/templates/claude/skill.hbs
@@ -2,6 +2,14 @@
 name: {{skill.name}}
 description: {{skill.description}}
 {{#if skill.[allowed-tools]}}allowed-tools: {{skill.[allowed-tools]}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}{{#if skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
+{{/if}}{{#if skill.user-invocable}}user-invocable: {{skill.user-invocable}}
+{{/if}}{{#if skill.paths}}paths:
+{{#each skill.paths}}  - {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/claude/skill.hbs
+++ b/public/v1/templates/claude/skill.hbs
@@ -5,9 +5,9 @@ description: {{skill.description}}
 {{/if}}{{#if skill.metadata}}metadata:
 {{#each skill.metadata}}  {{@key}}: {{this}}
 {{/each}}
-{{/if}}{{#if skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
-{{/if}}{{#if skill.user-invocable}}user-invocable: {{skill.user-invocable}}
-{{/if}}{{#if skill.paths}}paths:
+{{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
+{{/ifDefined}}{{#ifDefined skill.user-invocable}}user-invocable: {{skill.user-invocable}}
+{{/ifDefined}}{{#if skill.paths}}paths:
 {{#each skill.paths}}  - {{this}}
 {{/each}}
 {{/if}}---

--- a/public/v1/templates/claude/skill.hbs
+++ b/public/v1/templates/claude/skill.hbs
@@ -3,7 +3,7 @@ name: {{skill.name}}
 description: {{skill.description}}
 {{#if skill.[allowed-tools]}}allowed-tools: {{skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
 {{/ifDefined}}{{#ifDefined skill.user-invocable}}user-invocable: {{skill.user-invocable}}

--- a/public/v1/templates/claude/skill.hbs
+++ b/public/v1/templates/claude/skill.hbs
@@ -3,7 +3,7 @@ name: {{skill.name}}
 description: {{skill.description}}
 {{#if skill.[allowed-tools]}}allowed-tools: {{skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
 {{/ifDefined}}{{#ifDefined skill.user-invocable}}user-invocable: {{skill.user-invocable}}

--- a/public/v1/templates/cline/skill.hbs
+++ b/public/v1/templates/cline/skill.hbs
@@ -1,6 +1,9 @@
 ---
 name: {{json skill.name}}
 description: {{json skill.description}}
----
+{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/cline/skill.hbs
+++ b/public/v1/templates/cline/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/cline/skill.hbs
+++ b/public/v1/templates/cline/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/codex/skill.hbs
+++ b/public/v1/templates/codex/skill.hbs
@@ -2,7 +2,7 @@
 name: {{skill.name}}
 description: {{skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/codex/skill.hbs
+++ b/public/v1/templates/codex/skill.hbs
@@ -2,7 +2,7 @@
 name: {{skill.name}}
 description: {{skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/codex/skill.hbs
+++ b/public/v1/templates/codex/skill.hbs
@@ -1,6 +1,9 @@
 ---
 name: {{skill.name}}
 description: {{skill.description}}
----
+{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/copilot/skill.hbs
+++ b/public/v1/templates/copilot/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/copilot/skill.hbs
+++ b/public/v1/templates/copilot/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/copilot/skill.hbs
+++ b/public/v1/templates/copilot/skill.hbs
@@ -4,6 +4,9 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/cursor/skill.hbs
+++ b/public/v1/templates/cursor/skill.hbs
@@ -3,6 +3,10 @@ name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}{{#if skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/cursor/skill.hbs
+++ b/public/v1/templates/cursor/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
 {{/ifDefined}}---

--- a/public/v1/templates/cursor/skill.hbs
+++ b/public/v1/templates/cursor/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
 {{/ifDefined}}---

--- a/public/v1/templates/cursor/skill.hbs
+++ b/public/v1/templates/cursor/skill.hbs
@@ -6,7 +6,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.metadata}}metadata:
 {{#each skill.metadata}}  {{@key}}: {{this}}
 {{/each}}
-{{/if}}{{#if skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
-{{/if}}---
+{{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
+{{/ifDefined}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/deepagents/skill.hbs
+++ b/public/v1/templates/deepagents/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/deepagents/skill.hbs
+++ b/public/v1/templates/deepagents/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/deepagents/skill.hbs
+++ b/public/v1/templates/deepagents/skill.hbs
@@ -4,6 +4,9 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/factory-droid/skill.hbs
+++ b/public/v1/templates/factory-droid/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
 {{/ifDefined}}{{#ifDefined skill.user-invocable}}user-invocable: {{skill.user-invocable}}

--- a/public/v1/templates/factory-droid/skill.hbs
+++ b/public/v1/templates/factory-droid/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
 {{/ifDefined}}{{#ifDefined skill.user-invocable}}user-invocable: {{skill.user-invocable}}

--- a/public/v1/templates/factory-droid/skill.hbs
+++ b/public/v1/templates/factory-droid/skill.hbs
@@ -4,8 +4,8 @@ description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
 {{#each skill.metadata}}  {{@key}}: {{this}}
 {{/each}}
-{{/if}}{{#if skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
-{{/if}}{{#if skill.user-invocable}}user-invocable: {{skill.user-invocable}}
-{{/if}}---
+{{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
+{{/ifDefined}}{{#ifDefined skill.user-invocable}}user-invocable: {{skill.user-invocable}}
+{{/ifDefined}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/factory-droid/skill.hbs
+++ b/public/v1/templates/factory-droid/skill.hbs
@@ -1,6 +1,11 @@
 ---
 name: {{json skill.name}}
 description: {{json skill.description}}
----
+{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}{{#if skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
+{{/if}}{{#if skill.user-invocable}}user-invocable: {{skill.user-invocable}}
+{{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/gemini/skill.hbs
+++ b/public/v1/templates/gemini/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/gemini/skill.hbs
+++ b/public/v1/templates/gemini/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/gemini/skill.hbs
+++ b/public/v1/templates/gemini/skill.hbs
@@ -4,6 +4,9 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/goose/skill.hbs
+++ b/public/v1/templates/goose/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/goose/skill.hbs
+++ b/public/v1/templates/goose/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/goose/skill.hbs
+++ b/public/v1/templates/goose/skill.hbs
@@ -4,6 +4,9 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/junie/skill.hbs
+++ b/public/v1/templates/junie/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/junie/skill.hbs
+++ b/public/v1/templates/junie/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/junie/skill.hbs
+++ b/public/v1/templates/junie/skill.hbs
@@ -4,6 +4,9 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/kilocode/skill.hbs
+++ b/public/v1/templates/kilocode/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/kilocode/skill.hbs
+++ b/public/v1/templates/kilocode/skill.hbs
@@ -3,6 +3,9 @@ name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/kilocode/skill.hbs
+++ b/public/v1/templates/kilocode/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/kimi/skill.hbs
+++ b/public/v1/templates/kimi/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/kimi/skill.hbs
+++ b/public/v1/templates/kimi/skill.hbs
@@ -3,6 +3,9 @@ name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/kimi/skill.hbs
+++ b/public/v1/templates/kimi/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/mistral-vibe/skill.hbs
+++ b/public/v1/templates/mistral-vibe/skill.hbs
@@ -7,7 +7,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.metadata}}metadata:
 {{#each skill.metadata}}  {{@key}}: {{this}}
 {{/each}}
-{{/if}}{{#if skill.user-invocable}}user-invocable: {{skill.user-invocable}}
-{{/if}}---
+{{/if}}{{#ifDefined skill.user-invocable}}user-invocable: {{skill.user-invocable}}
+{{/ifDefined}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/mistral-vibe/skill.hbs
+++ b/public/v1/templates/mistral-vibe/skill.hbs
@@ -4,6 +4,10 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}{{#if skill.user-invocable}}user-invocable: {{skill.user-invocable}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/mistral-vibe/skill.hbs
+++ b/public/v1/templates/mistral-vibe/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}{{#ifDefined skill.user-invocable}}user-invocable: {{skill.user-invocable}}
 {{/ifDefined}}---

--- a/public/v1/templates/mistral-vibe/skill.hbs
+++ b/public/v1/templates/mistral-vibe/skill.hbs
@@ -5,7 +5,7 @@ description: {{json skill.description}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.[allowed-tools]}}allowed-tools: {{json skill.[allowed-tools]}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}{{#ifDefined skill.user-invocable}}user-invocable: {{skill.user-invocable}}
 {{/ifDefined}}---

--- a/public/v1/templates/opencode/skill.hbs
+++ b/public/v1/templates/opencode/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/opencode/skill.hbs
+++ b/public/v1/templates/opencode/skill.hbs
@@ -3,6 +3,9 @@ name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
+{{/if}}{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/opencode/skill.hbs
+++ b/public/v1/templates/opencode/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/pi/skill.hbs
+++ b/public/v1/templates/pi/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
 {{/ifDefined}}---

--- a/public/v1/templates/pi/skill.hbs
+++ b/public/v1/templates/pi/skill.hbs
@@ -1,6 +1,10 @@
 ---
 name: {{json skill.name}}
 description: {{json skill.description}}
----
+{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}{{#if skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
+{{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/pi/skill.hbs
+++ b/public/v1/templates/pi/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
 {{/ifDefined}}---

--- a/public/v1/templates/pi/skill.hbs
+++ b/public/v1/templates/pi/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
 {{#each skill.metadata}}  {{@key}}: {{this}}
 {{/each}}
-{{/if}}{{#if skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
-{{/if}}---
+{{/if}}{{#ifDefined skill.disable-model-invocation}}disable-model-invocation: {{skill.disable-model-invocation}}
+{{/ifDefined}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/qoder-cli/skill.hbs
+++ b/public/v1/templates/qoder-cli/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/qoder-cli/skill.hbs
+++ b/public/v1/templates/qoder-cli/skill.hbs
@@ -1,8 +1,9 @@
 ---
-name: {{skill.name}}
-description: {{skill.description}}
-{{#if skill.license}}license: {{skill.license}}
-{{/if}}{{#if skill.compatibility}}compatibility: {{skill.compatibility}}
+name: {{json skill.name}}
+description: {{json skill.description}}
+{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
 {{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/qoder-cli/skill.hbs
+++ b/public/v1/templates/qoder-cli/skill.hbs
@@ -1,7 +1,9 @@
 ---
 name: {{json skill.name}}
 description: {{json skill.description}}
-{{#if skill.metadata}}metadata:
+{{#if skill.license}}license: {{json skill.license}}
+{{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
+{{/if}}{{#if skill.metadata}}metadata:
 {{#each skill.metadata}}  {{@key}}: {{this}}
 {{/each}}
 {{/if}}---

--- a/public/v1/templates/qoder-cli/skill.hbs
+++ b/public/v1/templates/qoder-cli/skill.hbs
@@ -4,7 +4,7 @@ description: {{json skill.description}}
 {{#if skill.license}}license: {{json skill.license}}
 {{/if}}{{#if skill.compatibility}}compatibility: {{json skill.compatibility}}
 {{/if}}{{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/qwen/skill.hbs
+++ b/public/v1/templates/qwen/skill.hbs
@@ -1,6 +1,9 @@
 ---
 name: {{json skill.name}}
 description: {{json skill.description}}
----
+{{#if skill.metadata}}metadata:
+{{#each skill.metadata}}  {{@key}}: {{this}}
+{{/each}}
+{{/if}}---
 
 {{{skill.content}}}

--- a/public/v1/templates/qwen/skill.hbs
+++ b/public/v1/templates/qwen/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{json this}}
+{{#each skill.metadata}}  {{json @key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/public/v1/templates/qwen/skill.hbs
+++ b/public/v1/templates/qwen/skill.hbs
@@ -2,7 +2,7 @@
 name: {{json skill.name}}
 description: {{json skill.description}}
 {{#if skill.metadata}}metadata:
-{{#each skill.metadata}}  {{@key}}: {{this}}
+{{#each skill.metadata}}  {{@key}}: {{json this}}
 {{/each}}
 {{/if}}---
 

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -154,8 +154,15 @@ pub(crate) fn new_skill(opts: AddSkillOptions) -> Result<bool> {
         "e.g. Requires openspec CLI.",
     )?;
 
-    let content = SkillFeature::scaffold(&opts.name, &description, &license, &compatibility)
-        .context("failed to scaffold skill")?;
+    let content = SkillFeature::scaffold(
+        &opts.name,
+        &description,
+        &license,
+        &compatibility,
+        None,
+        None,
+    )
+    .context("failed to scaffold skill")?;
 
     write_file(&target, &content).context("failed to write SKILL.md")?;
 

--- a/src/constants/helpers.rs
+++ b/src/constants/helpers.rs
@@ -1,4 +1,5 @@
 pub(crate) const IF_EQ_HELPER: &str = "ifEq";
+pub(crate) const IF_DEFINED_HELPER: &str = "ifDefined";
 pub(crate) const JSON_HELPER: &str = "json";
 pub(crate) const TOML_HELPER: &str = "toml";
 pub(crate) const TOML_INLINE_HELPER: &str = "toml-inline";

--- a/src/constants/mocks.rs
+++ b/src/constants/mocks.rs
@@ -95,8 +95,20 @@ metadata:
   {{@key}}: {{this}}
 {{/each}}
 {{/if}}
+{{#if skill.disable-model-invocation}}
+disable-model-invocation: {{skill.disable-model-invocation}}
+{{/if}}
+{{#if skill.user-invocable}}
+user-invocable: {{skill.user-invocable}}
+{{/if}}
 {{#if skill.[allowed-tools]}}
 allowed-tools: {{skill.[allowed-tools]}}
+{{/if}}
+{{#if skill.paths}}
+paths:
+{{#each skill.paths}}
+  - {{this}}
+{{/each}}
 {{/if}}
 ---
 

--- a/src/constants/mocks.rs
+++ b/src/constants/mocks.rs
@@ -95,12 +95,12 @@ metadata:
   {{@key}}: {{this}}
 {{/each}}
 {{/if}}
-{{#if skill.disable-model-invocation}}
+{{#ifDefined skill.disable-model-invocation}}
 disable-model-invocation: {{skill.disable-model-invocation}}
-{{/if}}
-{{#if skill.user-invocable}}
+{{/ifDefined}}
+{{#ifDefined skill.user-invocable}}
 user-invocable: {{skill.user-invocable}}
-{{/if}}
+{{/ifDefined}}
 {{#if skill.[allowed-tools]}}
 allowed-tools: {{skill.[allowed-tools]}}
 {{/if}}

--- a/src/core/features/skill.rs
+++ b/src/core/features/skill.rs
@@ -27,6 +27,15 @@ pub(crate) struct SkillMetadata {
     pub metadata: Option<HashMap<String, String>>,
     #[serde(rename = "allowed-tools", skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<String>,
+    #[serde(
+        rename = "disable-model-invocation",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub disable_model_invocation: Option<bool>,
+    #[serde(rename = "user-invocable", skip_serializing_if = "Option::is_none")]
+    pub user_invocable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paths: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -68,6 +77,8 @@ impl SkillFeature {
         description: &str,
         license: &str,
         compatibility: &str,
+        disable_model_invocation: Option<bool>,
+        user_invocable: Option<bool>,
     ) -> Result<String> {
         let mut metadata_map = HashMap::new();
         metadata_map.insert("version".to_string(), "1.0".to_string());
@@ -88,6 +99,9 @@ impl SkillFeature {
                 },
                 metadata: Some(metadata_map),
                 allowed_tools: None,
+                disable_model_invocation,
+                user_invocable,
+                paths: None,
             },
             content: render_starter(SKILL_STARTER, name),
         };
@@ -227,6 +241,9 @@ Minimal body"#;
                 compatibility: None,
                 metadata: None,
                 allowed_tools: None,
+                disable_model_invocation: None,
+                user_invocable: None,
+                paths: None,
             },
             content: "Body".to_string(),
         };
@@ -238,6 +255,9 @@ Minimal body"#;
         assert!(!md.contains("compatibility"));
         assert!(!md.contains("metadata"));
         assert!(!md.contains("allowed-tools"));
+        assert!(!md.contains("disable-model-invocation"));
+        assert!(!md.contains("user-invocable"));
+        assert!(!md.contains("paths"));
         assert!(!md.contains("null"));
     }
 
@@ -254,6 +274,9 @@ Minimal body"#;
                 compatibility: Some("Claude, Codex".to_string()),
                 metadata: Some(metadata_map),
                 allowed_tools: Some("Read Write".to_string()),
+                disable_model_invocation: Some(true),
+                user_invocable: Some(false),
+                paths: Some(vec!["src/**/*.rs".to_string()]),
             },
             content: "Multi\nline\ncontent".to_string(),
         };
@@ -273,6 +296,15 @@ Minimal body"#;
             original.metadata.allowed_tools
         );
         assert_eq!(parsed.metadata.metadata, original.metadata.metadata);
+        assert_eq!(
+            parsed.metadata.disable_model_invocation,
+            original.metadata.disable_model_invocation
+        );
+        assert_eq!(
+            parsed.metadata.user_invocable,
+            original.metadata.user_invocable
+        );
+        assert_eq!(parsed.metadata.paths, original.metadata.paths);
         assert_eq!(parsed.content, original.content);
     }
 
@@ -289,6 +321,9 @@ Minimal body"#;
                 compatibility: Some("Claude, Codex".to_string()),
                 metadata: Some(meta_map),
                 allowed_tools: Some("Read Write".to_string()),
+                disable_model_invocation: Some(true),
+                user_invocable: Some(false),
+                paths: Some(vec!["src/**/*.rs".to_string()]),
             },
             content: "Skill body".to_string(),
         };
@@ -304,6 +339,9 @@ Minimal body"#;
                     "compatibility": "Claude, Codex",
                     "metadata": { "author": "tester" },
                     "allowed-tools": "Read Write",
+                    "disable-model-invocation": true,
+                    "user-invocable": false,
+                    "paths": ["src/**/*.rs"],
                     "content": "Skill body"
                 }
             })
@@ -320,6 +358,9 @@ Minimal body"#;
                 compatibility: None,
                 metadata: None,
                 allowed_tools: None,
+                disable_model_invocation: None,
+                user_invocable: None,
+                paths: None,
             },
             content: "Body".to_string(),
         };
@@ -332,6 +373,9 @@ Minimal body"#;
         assert!(skill_obj.get("compatibility").is_none());
         assert!(skill_obj.get("metadata").is_none());
         assert!(skill_obj.get("allowed-tools").is_none());
+        assert!(skill_obj.get("disable-model-invocation").is_none());
+        assert!(skill_obj.get("user-invocable").is_none());
+        assert!(skill_obj.get("paths").is_none());
     }
 
     #[test]
@@ -344,6 +388,9 @@ Minimal body"#;
                 compatibility: None,
                 metadata: None,
                 allowed_tools: None,
+                disable_model_invocation: None,
+                user_invocable: None,
+                paths: None,
             },
             content: "Body".to_string(),
         };
@@ -376,6 +423,9 @@ Body"#;
                 compatibility: None,
                 metadata: None,
                 allowed_tools: None,
+                disable_model_invocation: None,
+                user_invocable: None,
+                paths: None,
             },
             content: "Body".to_string(),
         };
@@ -407,7 +457,8 @@ Body"#;
     #[test]
     fn test_scaffold_produces_valid_markdown() {
         // scaffold returns markdown with all provided fields
-        let content = SkillFeature::scaffold("my-skill", "Does stuff", "MIT", "Claude").unwrap();
+        let content =
+            SkillFeature::scaffold("my-skill", "Does stuff", "MIT", "Claude", None, None).unwrap();
         assert!(content.starts_with("---"));
         assert!(content.contains("name: my-skill"));
         assert!(content.contains("description: Does stuff"));
@@ -419,7 +470,7 @@ Body"#;
     #[test]
     fn test_scaffold_empty_optional_fields_omitted() {
         // scaffold omits license and compatibility when empty
-        let content = SkillFeature::scaffold("sk", "desc", "", "").unwrap();
+        let content = SkillFeature::scaffold("sk", "desc", "", "", None, None).unwrap();
         assert!(!content.contains("license:"));
         assert!(!content.contains("compatibility:"));
     }
@@ -434,11 +485,104 @@ Body"#;
                 compatibility: None,
                 metadata: None,
                 allowed_tools: None,
+                disable_model_invocation: None,
+                user_invocable: None,
+                paths: None,
             },
             content: "Body".to_string(),
         };
 
         let value = skill.get_name_variable("my-skill").unwrap();
         assert_eq!(value, Some(json!({"skill": {"name": "my-skill"}})));
+    }
+
+    #[test]
+    fn test_parse_disable_model_invocation() {
+        let md = r#"---
+name: dmi-skill
+description: Disable model invocation test
+disable-model-invocation: true
+---
+
+Body"#;
+
+        let skill = SkillFeature::from_markdown(md).unwrap();
+        assert_eq!(skill.metadata.disable_model_invocation, Some(true));
+    }
+
+    #[test]
+    fn test_parse_user_invocable() {
+        let md = r#"---
+name: ui-skill
+description: User invocable test
+user-invocable: false
+---
+
+Body"#;
+
+        let skill = SkillFeature::from_markdown(md).unwrap();
+        assert_eq!(skill.metadata.user_invocable, Some(false));
+    }
+
+    #[test]
+    fn test_parse_paths() {
+        let md = r#"---
+name: paths-skill
+description: Paths test
+paths:
+  - src/**/*.rs
+  - tests/**
+---
+
+Body"#;
+
+        let skill = SkillFeature::from_markdown(md).unwrap();
+        assert_eq!(
+            skill.metadata.paths,
+            Some(vec!["src/**/*.rs".to_string(), "tests/**".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_serialize_new_fields_when_present() {
+        let skill = SkillFeature {
+            metadata: SkillMetadata {
+                name: "new-fields".to_string(),
+                description: "Has new fields".to_string(),
+                license: None,
+                compatibility: None,
+                metadata: None,
+                allowed_tools: None,
+                disable_model_invocation: Some(true),
+                user_invocable: Some(false),
+                paths: Some(vec!["src/**".to_string()]),
+            },
+            content: "Body".to_string(),
+        };
+
+        let md = skill.to_markdown().unwrap();
+        assert!(md.contains("disable-model-invocation: true"));
+        assert!(md.contains("user-invocable: false"));
+        assert!(md.contains("paths:"));
+        assert!(md.contains("- src/**"));
+    }
+
+    #[test]
+    fn test_parse_all_extension_fields_together() {
+        let md = r#"---
+name: full-extensions
+description: All extension fields
+disable-model-invocation: true
+user-invocable: false
+paths:
+  - "**/*.rs"
+---
+
+Body"#;
+
+        let skill = SkillFeature::from_markdown(md).unwrap();
+        assert_eq!(skill.metadata.disable_model_invocation, Some(true));
+        assert_eq!(skill.metadata.user_invocable, Some(false));
+        assert_eq!(skill.metadata.paths, Some(vec!["**/*.rs".to_string()]));
     }
 }

--- a/src/templates/helpers.rs
+++ b/src/templates/helpers.rs
@@ -31,6 +31,33 @@ impl HelperDef for IfEqHelper {
 }
 
 #[derive(Clone, Copy)]
+pub struct IfDefinedHelper;
+
+impl HelperDef for IfDefinedHelper {
+    fn call<'reg: 'rc, 'rc>(
+        &self,
+        h: &Helper<'rc>,
+        r: &'reg Handlebars<'reg>,
+        ctx: &'rc Context,
+        rc: &mut RenderContext<'reg, 'rc>,
+        out: &mut dyn Output,
+    ) -> HelperResult {
+        let param = h.param(0).map(|v| v.value());
+        let is_defined = param.map(|v| !v.is_null()).unwrap_or(false);
+
+        if is_defined {
+            if let Some(template) = h.template() {
+                template.render(r, ctx, rc, out)?;
+            }
+        } else if let Some(inverse) = h.inverse() {
+            inverse.render(r, ctx, rc, out)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
 pub struct JsonHelper;
 
 impl HelperDef for JsonHelper {
@@ -397,5 +424,95 @@ mod tests {
         let data = json!({"name": "hello"});
         let result = handlebars.render("test", &data).unwrap();
         assert_eq!(result.trim(), "hello");
+    }
+
+    #[test]
+    fn test_if_defined_helper_true_value() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("ifDefined", Box::new(IfDefinedHelper));
+
+        let template = "{{#ifDefined flag}}yes{{else}}no{{/ifDefined}}";
+        handlebars
+            .register_template_string("test", template)
+            .unwrap();
+
+        let data = json!({"flag": true});
+        let result = handlebars.render("test", &data).unwrap();
+        assert_eq!(result, "yes");
+    }
+
+    #[test]
+    fn test_if_defined_helper_false_value() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("ifDefined", Box::new(IfDefinedHelper));
+
+        let template = "{{#ifDefined flag}}flag: {{flag}}{{else}}omitted{{/ifDefined}}";
+        handlebars
+            .register_template_string("test", template)
+            .unwrap();
+
+        let data = json!({"flag": false});
+        let result = handlebars.render("test", &data).unwrap();
+        assert_eq!(result, "flag: false");
+    }
+
+    #[test]
+    fn test_if_defined_helper_undefined() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("ifDefined", Box::new(IfDefinedHelper));
+
+        let template = "{{#ifDefined missing}}yes{{else}}no{{/ifDefined}}";
+        handlebars
+            .register_template_string("test", template)
+            .unwrap();
+
+        let data = json!({});
+        let result = handlebars.render("test", &data).unwrap();
+        assert_eq!(result, "no");
+    }
+
+    #[test]
+    fn test_if_defined_helper_null() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("ifDefined", Box::new(IfDefinedHelper));
+
+        let template = "{{#ifDefined value}}yes{{else}}no{{/ifDefined}}";
+        handlebars
+            .register_template_string("test", template)
+            .unwrap();
+
+        let data = json!({"value": null});
+        let result = handlebars.render("test", &data).unwrap();
+        assert_eq!(result, "no");
+    }
+
+    #[test]
+    fn test_if_defined_helper_zero() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("ifDefined", Box::new(IfDefinedHelper));
+
+        let template = "{{#ifDefined count}}count: {{count}}{{else}}omitted{{/ifDefined}}";
+        handlebars
+            .register_template_string("test", template)
+            .unwrap();
+
+        let data = json!({"count": 0});
+        let result = handlebars.render("test", &data).unwrap();
+        assert_eq!(result, "count: 0");
+    }
+
+    #[test]
+    fn test_if_defined_helper_empty_string() {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper("ifDefined", Box::new(IfDefinedHelper));
+
+        let template = "{{#ifDefined name}}name: {{name}}{{else}}omitted{{/ifDefined}}";
+        handlebars
+            .register_template_string("test", template)
+            .unwrap();
+
+        let data = json!({"name": ""});
+        let result = handlebars.render("test", &data).unwrap();
+        assert_eq!(result, "name: ");
     }
 }

--- a/src/templates/templater.rs
+++ b/src/templates/templater.rs
@@ -3,21 +3,22 @@ use handlebars::Handlebars;
 use serde_json::Value;
 use std::sync::OnceLock;
 
-use crate::templates::variables::get_env_variables;
+use crate::templates::variables::{get_dir_variables, get_env_variables};
 use crate::utils::path::get_application_dir;
 use crate::{
-    constants::helpers::{JSON_HELPER, TOML_HELPER, TOML_INLINE_HELPER, YAML_HELPER},
-    templates::{
-        helpers::{IfEqHelper, JsonHelper, TomlHelper, TomlInlineHelper, YamlHelper},
-        variables::{get_command_name_variable, get_dir_variables, get_skill_name_variable},
-    },
+    constants::file::{GLOBAL_CONFIG_FILE, LOCAL_CONFIG_FILE},
+    utils::json::{merge_json, merge_many_json},
 };
 use crate::{
-    constants::{
-        file::{GLOBAL_CONFIG_FILE, LOCAL_CONFIG_FILE},
-        helpers::IF_EQ_HELPER,
+    constants::helpers::{
+        IF_DEFINED_HELPER, IF_EQ_HELPER, JSON_HELPER, TOML_HELPER, TOML_INLINE_HELPER, YAML_HELPER,
     },
-    utils::json::{merge_json, merge_many_json},
+    templates::{
+        helpers::{
+            IfDefinedHelper, IfEqHelper, JsonHelper, TomlHelper, TomlInlineHelper, YamlHelper,
+        },
+        variables::{get_command_name_variable, get_skill_name_variable},
+    },
 };
 
 static TEMPLATER: OnceLock<Templater> = OnceLock::new();
@@ -88,6 +89,7 @@ impl Templater {
         let globals = Self::load_default_variables()?;
         let mut handlebar = Handlebars::new();
         handlebar.register_helper(IF_EQ_HELPER, Box::new(IfEqHelper));
+        handlebar.register_helper(IF_DEFINED_HELPER, Box::new(IfDefinedHelper));
         handlebar.register_helper(JSON_HELPER, Box::new(JsonHelper));
         handlebar.register_helper(TOML_HELPER, Box::new(TomlHelper));
         handlebar.register_helper(TOML_INLINE_HELPER, Box::new(TomlInlineHelper));

--- a/tests/e2e/skills.test.ts
+++ b/tests/e2e/skills.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@microsoft/tui-test";
 import {
@@ -813,6 +819,44 @@ Body`,
 		}
 	});
 
+	// deployed output contains disable-model-invocation when false
+	test("deployed output contains disable-model-invocation when false", async () => {
+		const d = makeTmpDir();
+		try {
+			initWithLocalProvider(d);
+			run(
+				[
+					"init",
+					"--template",
+					"starter",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			const skillDir = join(d, ".dotagents/skills/dmi-false");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: dmi-false
+description: Has disable-model-invocation false
+disable-model-invocation: false
+---
+
+Body`,
+			);
+			run(["deploy", "--offline"], d);
+			const deployed = readFileSync(
+				join(d, ".mycode/skills/dmi-false/SKILL.md"),
+				"utf8",
+			);
+			expect(deployed).toContain("disable-model-invocation: false");
+		} finally {
+			cleanup(d);
+		}
+	});
+
 	// deployed output contains user-invocable when set
 	test("deployed output contains user-invocable when set", async () => {
 		const d = makeTmpDir();
@@ -883,6 +927,44 @@ Body`,
 				"utf8",
 			);
 			expect(deployed).not.toContain("user-invocable");
+		} finally {
+			cleanup(d);
+		}
+	});
+
+	// deployed output contains user-invocable when false
+	test("deployed output contains user-invocable when false", async () => {
+		const d = makeTmpDir();
+		try {
+			initWithLocalProvider(d);
+			run(
+				[
+					"init",
+					"--template",
+					"starter",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			const skillDir = join(d, ".dotagents/skills/ui-false");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: ui-false
+description: Has user-invocable false
+user-invocable: false
+---
+
+Body`,
+			);
+			run(["deploy", "--offline"], d);
+			const deployed = readFileSync(
+				join(d, ".mycode/skills/ui-false/SKILL.md"),
+				"utf8",
+			);
+			expect(deployed).toContain("user-invocable: false");
 		} finally {
 			cleanup(d);
 		}

--- a/tests/e2e/skills.test.ts
+++ b/tests/e2e/skills.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@microsoft/tui-test";
 import {
@@ -650,6 +650,318 @@ test.describe("skills deploy-default", () => {
 			expect(existsSync(join(d, ".mycode/skills/hello-skill/SKILL.md"))).toBe(
 				false,
 			);
+		} finally {
+			cleanup(d);
+		}
+	});
+});
+
+// ── skills deploy – new fields ─────────────────────────────────────────────────
+
+test.describe("skills deploy new fields", () => {
+	// deployed output contains metadata field when present
+	test("deployed output contains metadata when present", async () => {
+		const d = makeTmpDir();
+		try {
+			initWithLocalProvider(d);
+			run(
+				[
+					"init",
+					"--template",
+					"starter",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			const skillDir = join(d, ".dotagents/skills/meta-skill");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: meta-skill
+description: Has metadata
+metadata:
+  author: tester
+  version: "2.0"
+---
+
+Body content`,
+			);
+			run(["deploy", "--offline"], d);
+			const deployed = readFileSync(
+				join(d, ".mycode/skills/meta-skill/SKILL.md"),
+				"utf8",
+			);
+			expect(deployed).toContain("metadata:");
+			expect(deployed).toContain("author: tester");
+			expect(deployed).toContain("version:");
+		} finally {
+			cleanup(d);
+		}
+	});
+
+	// deployed output omits metadata when absent
+	test("deployed output omits metadata when absent", async () => {
+		const d = makeTmpDir();
+		try {
+			initWithLocalProvider(d);
+			run(
+				[
+					"init",
+					"--template",
+					"starter",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			const skillDir = join(d, ".dotagents/skills/no-meta");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: no-meta
+description: No metadata
+---
+
+Body`,
+			);
+			run(["deploy", "--offline"], d);
+			const deployed = readFileSync(
+				join(d, ".mycode/skills/no-meta/SKILL.md"),
+				"utf8",
+			);
+			expect(deployed).not.toContain("metadata:");
+		} finally {
+			cleanup(d);
+		}
+	});
+
+	// deployed output contains disable-model-invocation when true
+	test("deployed output contains disable-model-invocation when true", async () => {
+		const d = makeTmpDir();
+		try {
+			initWithLocalProvider(d);
+			run(
+				[
+					"init",
+					"--template",
+					"starter",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			const skillDir = join(d, ".dotagents/skills/dmi-skill");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: dmi-skill
+description: Has disable-model-invocation
+disable-model-invocation: true
+---
+
+Body`,
+			);
+			run(["deploy", "--offline"], d);
+			const deployed = readFileSync(
+				join(d, ".mycode/skills/dmi-skill/SKILL.md"),
+				"utf8",
+			);
+			expect(deployed).toContain("disable-model-invocation: true");
+		} finally {
+			cleanup(d);
+		}
+	});
+
+	// deployed output omits disable-model-invocation when absent
+	test("deployed output omits disable-model-invocation when absent", async () => {
+		const d = makeTmpDir();
+		try {
+			initWithLocalProvider(d);
+			run(
+				[
+					"init",
+					"--template",
+					"starter",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			const skillDir = join(d, ".dotagents/skills/no-dmi");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: no-dmi
+description: No dmi
+---
+
+Body`,
+			);
+			run(["deploy", "--offline"], d);
+			const deployed = readFileSync(
+				join(d, ".mycode/skills/no-dmi/SKILL.md"),
+				"utf8",
+			);
+			expect(deployed).not.toContain("disable-model-invocation");
+		} finally {
+			cleanup(d);
+		}
+	});
+
+	// deployed output contains user-invocable when set
+	test("deployed output contains user-invocable when set", async () => {
+		const d = makeTmpDir();
+		try {
+			initWithLocalProvider(d);
+			run(
+				[
+					"init",
+					"--template",
+					"starter",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			const skillDir = join(d, ".dotagents/skills/ui-skill");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: ui-skill
+description: Has user-invocable
+user-invocable: true
+---
+
+Body`,
+			);
+			run(["deploy", "--offline"], d);
+			const deployed = readFileSync(
+				join(d, ".mycode/skills/ui-skill/SKILL.md"),
+				"utf8",
+			);
+			expect(deployed).toContain("user-invocable: true");
+		} finally {
+			cleanup(d);
+		}
+	});
+
+	// deployed output omits user-invocable when absent
+	test("deployed output omits user-invocable when absent", async () => {
+		const d = makeTmpDir();
+		try {
+			initWithLocalProvider(d);
+			run(
+				[
+					"init",
+					"--template",
+					"starter",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			const skillDir = join(d, ".dotagents/skills/no-ui");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: no-ui
+description: No ui
+---
+
+Body`,
+			);
+			run(["deploy", "--offline"], d);
+			const deployed = readFileSync(
+				join(d, ".mycode/skills/no-ui/SKILL.md"),
+				"utf8",
+			);
+			expect(deployed).not.toContain("user-invocable");
+		} finally {
+			cleanup(d);
+		}
+	});
+
+	// deployed output contains paths when set
+	test("deployed output contains paths when set", async () => {
+		const d = makeTmpDir();
+		try {
+			initWithLocalProvider(d);
+			run(
+				[
+					"init",
+					"--template",
+					"starter",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			const skillDir = join(d, ".dotagents/skills/paths-skill");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: paths-skill
+description: Has paths
+paths:
+  - src/**/*.rs
+  - tests/**
+---
+
+Body`,
+			);
+			run(["deploy", "--offline"], d);
+			const deployed = readFileSync(
+				join(d, ".mycode/skills/paths-skill/SKILL.md"),
+				"utf8",
+			);
+			expect(deployed).toContain("paths:");
+			expect(deployed).toContain("- src/**/*.rs");
+			expect(deployed).toContain("- tests/**");
+		} finally {
+			cleanup(d);
+		}
+	});
+
+	// deployed output omits paths when absent
+	test("deployed output omits paths when absent", async () => {
+		const d = makeTmpDir();
+		try {
+			initWithLocalProvider(d);
+			run(
+				[
+					"init",
+					"--template",
+					"starter",
+					"--features",
+					"commands,instructions,mcp,skills",
+				],
+				d,
+			);
+			const skillDir = join(d, ".dotagents/skills/no-paths");
+			mkdirSync(skillDir, { recursive: true });
+			writeFileSync(
+				join(skillDir, "SKILL.md"),
+				`---
+name: no-paths
+description: No paths
+---
+
+Body`,
+			);
+			run(["deploy", "--offline"], d);
+			const deployed = readFileSync(
+				join(d, ".mycode/skills/no-paths/SKILL.md"),
+				"utf8",
+			);
+			expect(deployed).not.toMatch(/^paths:/m);
 		} finally {
 			cleanup(d);
 		}


### PR DESCRIPTION
## Summary

- Adds three new optional fields to `SkillMetadata`: `disable-model-invocation` (`Option<bool>`), `user-invocable` (`Option<bool>`), and `paths` (`Option<Vec<String>>`) — Claude Code invocation-control extensions
- Renders the existing `metadata` key-value map in all 20 provider `skill.hbs` templates (was stored but never output)
- Renders `disable-model-invocation` in 4 provider templates (Claude, Cursor, Factory Droid, Pi)
- Renders `user-invocable` in 3 provider templates (Claude, Factory Droid, Mistral Vibe)
- Renders `paths` as a YAML list in the Claude provider template
- Updates `SkillFeature::scaffold()` to accept the new optional boolean parameters
- Adds unit tests for parsing, serialization, roundtrip, and `to_value` with new fields
- Adds e2e tests for deployed output containing new fields and metadata
- Updates the `openspec/specs/skill-feature/spec.md` with new requirements
- All fields are additive and `Option<>` — no breaking changes

## Testing

- `mise check` (cargo fmt + cargo clippy) passes
- `mise tests` (unit + integration + e2e) passes
- Unit tests verify: parse of new fields, serialization omits None fields, roundtrip preserves all fields, `to_value` includes new fields when present, `to_value` omits new fields when absent
- E2E tests verify: deploy skill with `metadata` to a provider renders the YAML map, deploy skill with `disable-model-invocation: true` to claude renders the field, deploy skill with `user-invocable: false` to factory-droid renders the field, deploy skill with `paths` to claude renders the YAML list, extension fields are omitted for unsupported providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three optional skill frontmatter fields: disable-model-invocation, user-invocable, and paths.
  * Templates now conditionally render metadata for all providers; supported providers emit the new fields.
  * Scaffolding/init accepts and preserves these optional fields; omitted when absent.
  * Added a "defined" template helper for defined-vs-null conditionals.

* **Tests**
  * New e2e and serialization tests verifying parsing, omission, and provider-specific rendering.

* **Documentation**
  * Updated specs, proposals, and task docs describing behavior and rendering rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soorya-u/dotagents/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->