### PR TITLE
Add OpenSpec proposal for provider ignore files

### DIFF
--- a/openspec/changes/add-provider-ignore-files/.openspec.yaml
+++ b/openspec/changes/add-provider-ignore-files/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/add-provider-ignore-files/design.md
+++ b/openspec/changes/add-provider-ignore-files/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Dotagents currently deploys commands, instructions, MCP configs, and skills to 20+ AI agent providers. Many of these providers support ignore files that control which files the agent reads or indexes, but dotagents does not manage these files. Users must manually create and maintain them. The deploy pipeline already has a feature abstraction (`FeatureTrait`) and a renderer that iterates over providers and features — adding `ignore` as a new feature type fits cleanly into this architecture. Additionally, `init` should scaffold an ignore patterns file when the user selects the ignore feature.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `ignore` as a first-class feature alongside `commands`, `instructions`, `mcp`, `skills`
+- Support all 20 providers with ignore file templates (each follows the `.<name>ignore` convention)
+- Each provider gets a template (`ignore.hbs`) that renders a list of ignore patterns
+- Ignore patterns are sourced from a configurable list in `config.toml` (global + per-provider)
+- Deployed ignore files are tracked in the gitignore fence
+- `init` scaffolds a default ignore patterns file when the ignore feature is selected
+- TUI wizard includes "Ignore Patterns" as a selectable feature
+
+**Non-Goals:**
+- No automatic pattern generation from deployed file paths (users define patterns explicitly)
+- No permission-file support (separate concern — tracked in GitHub issue #156)
+- No migration of existing manually-created ignore files
+
+## Decisions
+
+### 1. Ignore patterns as a simple list of strings
+**Decision:** `IgnoreFeature` holds a `Vec<String>` of patterns, one per line in the rendered output.
+**Rationale:** All supported providers use newline-separated glob patterns. No need for complex structures.
+**Alternatives considered:**
+- Structured patterns with comments/metadata — overkill for current use case
+- Single string blob — harder to manipulate in templates and tests
+
+### 2. Global patterns + per-provider overrides via config
+**Decision:** Users define `[ignore]` table in config with `patterns = [...]`. Per-provider overrides via `[providers.<name>.ignore.variables]` or a dedicated `patterns` field.
+**Rationale:** Matches existing pattern for per-provider feature settings. Keeps config familiar.
+**Alternatives considered:**
+- Separate `.dotagents/ignore` file — adds complexity, config.toml already handles this
+- Only global patterns — too inflexible for provider-specific needs
+
+### 3. Template renders patterns directly (no two-phase rendering)
+**Decision:** Unlike commands/instructions, ignore templates skip the two-phase content rendering and render directly against `var.*` and `ignore.patterns`.
+**Rationale:** Ignore files don't have frontmatter or complex structure. Two-phase rendering adds no value.
+**Alternatives considered:**
+- Use two-phase rendering for consistency — unnecessary complexity
+- Special renderer path — simpler to skip phase 1 for this feature type
+
+### 4. Ignore feature is singleton (one file per provider, not per-item)
+**Decision:** `get_file_name()` returns `None`, so each provider gets exactly one ignore file.
+**Rationale:** Providers have a single ignore file (`.ignore`, `.aiignore`, etc.), not one per pattern.
+**Alternatives considered:**
+- One file per pattern — doesn't match any provider's format
+
+### 5. Provider template paths follow existing convention
+**Decision:** Each provider gets `public/v1/templates/<slug>/ignore.hbs` with target path in `provider.toml`.
+**Rationale:** Consistent with existing feature templates. Remote template resolution already handles this.
+**Alternatives considered:**
+- Shared template with provider-specific variables — harder to maintain, less flexible
+
+### 6. Init scaffolds a default ignore patterns file
+**Decision:** When the user selects the ignore feature during `init`, a default `ignore` file is created in `.dotagents/` with common patterns (e.g., `node_modules/`, `.git/`, `target/`).
+**Rationale:** Matches the existing pattern for commands, instructions, MCP, and skills — each feature gets a mock file during init.
+**Alternatives considered:**
+- No default file — leaves users with no starting point
+- Empty file — less helpful than a sensible default
+
+### 7. All 20 providers get ignore templates
+**Decision:** Every provider in the registry gets an `ignore.hbs` template, even if the ignore file format is not well-documented.
+**Rationale:** Most providers follow the `.<name>ignore` convention. Users can customize templates later. Better to provide a starting point than leave providers unsupported.
+**Alternatives considered:**
+- Only add templates for well-documented providers — leaves gaps for users of other providers
+
+## Risks / Trade-offs
+
+- **[Risk]** Provider ignore file formats may change — **Mitigation:** Templates are user-editable; updates only require template changes, not core code
+- **[Risk]** Users may have existing ignore files that get overwritten — **Mitigation:** Deploy prompts before overwriting (existing behavior for all templates)
+- **[Trade-off]** No automatic pattern inference from deployed files — keeps implementation simple but requires manual pattern definition
+- **[Risk]** Some provider ignore formats are not well-documented — **Mitigation:** Use the `.<name>ignore` convention as a sensible default; users can customize templates
+
+## Migration Plan
+
+1. Add `ignore` feature to config schema — backward compatible (new field is optional)
+2. Add templates to registry — no impact on existing deployments
+3. Users opt-in by adding `ignore` to `features` list and configuring patterns
+4. No rollback needed — removing `ignore` from features stops rendering, existing files remain on disk
+
+## Open Questions
+
+- Should ignore patterns support variable interpolation (e.g., `{{ dir.workspace }}/.claude/`)?
+- What is the exact ignore file format for providers like codex and amp? (Use `.<name>ignore` as default)

--- a/openspec/changes/add-provider-ignore-files/design.md
+++ b/openspec/changes/add-provider-ignore-files/design.md
@@ -6,9 +6,9 @@ Dotagents currently deploys commands, instructions, MCP configs, and skills to 2
 
 **Goals:**
 - Add `ignore` as a first-class feature alongside `commands`, `instructions`, `mcp`, `skills`
-- Support all 20 providers with ignore file templates (each follows the `.<name>ignore` convention)
+- Support all supported providers with ignore file templates (each follows the `.<name>ignore` convention)
 - Each provider gets a template (`ignore.hbs`) that renders a list of ignore patterns
-- Ignore patterns are sourced from a configurable list in `config.toml` (global + per-provider)
+- Ignore patterns are sourced from `.dotagents/.agentignore` (newline-separated, like `INSTRUCTIONS.md`) and merged with per-provider `patterns` from config
 - Deployed ignore files are tracked in the gitignore fence
 - `init` scaffolds a default ignore patterns file when the ignore feature is selected
 - TUI wizard includes "Ignore Patterns" as a selectable feature
@@ -27,12 +27,12 @@ Dotagents currently deploys commands, instructions, MCP configs, and skills to 2
 - Structured patterns with comments/metadata — overkill for current use case
 - Single string blob — harder to manipulate in templates and tests
 
-### 2. Global patterns + per-provider overrides via config
-**Decision:** Users define `[ignore]` table in config with `patterns = [...]`. Per-provider overrides via `[providers.<name>.ignore.variables]` or a dedicated `patterns` field.
-**Rationale:** Matches existing pattern for per-provider feature settings. Keeps config familiar.
+### 2. Patterns sourced from `.agentignore` file only
+**Decision:** All ignore patterns come from `.dotagents/.agentignore` (one pattern per line). No config-based pattern overrides.
+**Rationale:** Follows the established pattern for `INSTRUCTIONS.md` and `mcp.jsonc` — a single source file that users edit. Keeps config clean and avoids ambiguity.
 **Alternatives considered:**
-- Separate `.dotagents/ignore` file — adds complexity, config.toml already handles this
-- Only global patterns — too inflexible for provider-specific needs
+- Global `[ignore]` table in config.toml — duplicates what a source file already does
+- Per-provider `patterns` arrays — adds complexity for a use case that variables already solve
 
 ### 3. Template renders patterns directly (no two-phase rendering)
 **Decision:** Unlike commands/instructions, ignore templates skip the two-phase content rendering and render directly against `var.*` and `ignore.patterns`.
@@ -53,14 +53,14 @@ Dotagents currently deploys commands, instructions, MCP configs, and skills to 2
 **Alternatives considered:**
 - Shared template with provider-specific variables — harder to maintain, less flexible
 
-### 6. Init scaffolds a default ignore patterns file
-**Decision:** When the user selects the ignore feature during `init`, a default `ignore` file is created in `.dotagents/` with common patterns (e.g., `node_modules/`, `.git/`, `target/`).
-**Rationale:** Matches the existing pattern for commands, instructions, MCP, and skills — each feature gets a mock file during init.
+### 6. Init scaffolds `.agentignore` with common patterns
+**Decision:** When the user selects the ignore feature during `init`, a default `.dotagents/.agentignore` file is created with common patterns (e.g., `node_modules/`, `.git/`, `target/`).
+**Rationale:** Matches the existing pattern for `INSTRUCTIONS.md` and `mcp.jsonc` — each feature gets a mock file during init.
 **Alternatives considered:**
 - No default file — leaves users with no starting point
 - Empty file — less helpful than a sensible default
 
-### 7. All 20 providers get ignore templates
+### 7. All supported providers get ignore templates
 **Decision:** Every provider in the registry gets an `ignore.hbs` template, even if the ignore file format is not well-documented.
 **Rationale:** Most providers follow the `.<name>ignore` convention. Users can customize templates later. Better to provide a starting point than leave providers unsupported.
 **Alternatives considered:**

--- a/openspec/changes/add-provider-ignore-files/proposal.md
+++ b/openspec/changes/add-provider-ignore-files/proposal.md
@@ -5,7 +5,7 @@ Many AI coding agents support ignore files that control which files the agent re
 ## What Changes
 
 - New `ignore` feature added to the feature system (alongside `commands`, `instructions`, `mcp`, `skills`)
-- New `Ignore` option in `dotagents init` feature selection (TUI wizard + `--features` flag + `--no-ignore` flag)
+- New `Ignore` option in `dotagents init` feature selection (TUI wizard + `--features` flag)
 - Provider templates updated for all 20 providers that support ignore files:
   - **opencode**: `.ignore`
   - **auggie**: `.augmentignore`
@@ -47,6 +47,7 @@ Many AI coding agents support ignore files that control which files the agent re
 
 - **New code**: `src/core/features/ignore.rs` (new `IgnoreFeature` implementation), provider template files under `public/v1/templates/<provider>/ignore.hbs`
 - **Modified code**: `src/core/features/common.rs` (add `Ignore` to `Feature` enum), `src/core/config/common.rs` (add `ignore` to `Features`), `src/cli/options.rs` (add `Ignore` to init `Feature` enum), `src/cli/init.rs` (wire ignore scaffolding), `src/cli/ui/init.rs` (add ignore to TUI multiselect), `src/cli/deploy.rs` (wire ignore feature into deploy loop), `src/utils/gitignore.rs` (include ignore files in fence)
-- **Config schema**: `Features` struct gains `ignore: Option<FeatureSettings>`
+- **Config schema**: `Features` struct gains `ignore: Option<FeatureSettings>`; per-provider `[providers.<name>.ignore]` supports `disabled = true`
+- **Source file**: `.dotagents/.agentignore` — newline-separated ignore patterns, loaded and templated to all providers during deploy
 - **Templates**: 20 new `.hbs` template files for provider-specific ignore formats
 - **Registry**: `registry.json` updated with new template checksums

--- a/openspec/changes/add-provider-ignore-files/proposal.md
+++ b/openspec/changes/add-provider-ignore-files/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Many AI coding agents support ignore files that control which files the agent reads or indexes. Currently, dotagents deploys commands, instructions, MCP configs, and skills to 20+ providers, but does not manage their ignore files. Users must manually create and maintain `.ignore`, `.aiignore`, `.claudeignore`, etc. Adding ignore file support lets dotagents automatically generate and update these files during `deploy`, and scaffold them during `init`, keeping them in sync with deployed content and preventing agents from reading stale or irrelevant files.
+
+## What Changes
+
+- New `ignore` feature added to the feature system (alongside `commands`, `instructions`, `mcp`, `skills`)
+- New `Ignore` option in `dotagents init` feature selection (TUI wizard + `--features` flag + `--no-ignore` flag)
+- Provider templates updated for all 20 providers that support ignore files:
+  - **opencode**: `.ignore`
+  - **auggie**: `.augmentignore`
+  - **autohand**: `.autohandignore`
+  - **junie**: `.aiignore`
+  - **pi**: `.piignore`
+  - **goose**: `.gooseignore`
+  - **cline**: `.clineignore`
+  - **gemini**: `.geminiignore`
+  - **qwen**: `.qwenignore`
+  - **kilocode**: `.kilocodeignore`
+  - **cursor**: `.cursorignore`
+  - **claude**: `.claudeignore`
+  - **copilot**: `.github/copilotignore`
+  - **codex**: `.codexignore`
+  - **factory-droid**: `.factoryignore`
+  - **deepagents**: `.deepagentsignore`
+  - **kimi**: `.kimiignore`
+  - **mistral-vibe**: `.mistralignore`
+  - **qoder-cli**: `.qoderignore`
+  - **amp**: `.ampignore`
+- New `IgnoreFeature` type implementing `FeatureTrait` to handle ignore pattern lists
+- Deploy pipeline renders ignore templates per-provider and writes to target paths
+- Init scaffolds a default ignore patterns file when the ignore feature is selected
+- Existing gitignore fence logic extended to include deployed ignore files
+
+## Capabilities
+
+### New Capabilities
+- `ignore-feature`: New feature type for managing provider-specific ignore files. Handles pattern lists, template rendering, file output, and init scaffolding.
+- `ignore-provider-templates`: Template definitions for all 20 providers' ignore file formats.
+- `ignore-init-scaffold`: Init-time scaffolding of ignore patterns file when the ignore feature is selected.
+
+### Modified Capabilities
+- `deploy-pipeline`: Deploy now processes the `ignore` feature alongside existing features. Cache and gitignore logic extended to track ignore files.
+- `init-wizard`: TUI wizard and CLI flags extended to include the ignore feature selection.
+
+## Impact
+
+- **New code**: `src/core/features/ignore.rs` (new `IgnoreFeature` implementation), provider template files under `public/v1/templates/<provider>/ignore.hbs`
+- **Modified code**: `src/core/features/common.rs` (add `Ignore` to `Feature` enum), `src/core/config/common.rs` (add `ignore` to `Features`), `src/cli/options.rs` (add `Ignore` to init `Feature` enum), `src/cli/init.rs` (wire ignore scaffolding), `src/cli/ui/init.rs` (add ignore to TUI multiselect), `src/cli/deploy.rs` (wire ignore feature into deploy loop), `src/utils/gitignore.rs` (include ignore files in fence)
+- **Config schema**: `Features` struct gains `ignore: Option<FeatureSettings>`
+- **Templates**: 20 new `.hbs` template files for provider-specific ignore formats
+- **Registry**: `registry.json` updated with new template checksums

--- a/openspec/changes/add-provider-ignore-files/specs/deploy-pipeline/spec.md
+++ b/openspec/changes/add-provider-ignore-files/specs/deploy-pipeline/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Deploy pipeline processes ignore feature
+The system SHALL process the `ignore` feature in the deploy pipeline alongside `commands`, `instructions`, `mcp`, and `skills`. When `"ignore"` is in the `features` list, the pipeline SHALL load patterns from config, build an `IgnoreFeature`, and render it once per active provider.
+
+#### Scenario: Deploy writes ignore file for each provider
+- **WHEN** `features = ["commands", "ignore"]` and `targets = ["opencode", "junie"]` with patterns `["node_modules/"]`
+- **THEN** the system SHALL write `.ignore` for opencode and `.aiignore` for junie, each containing `node_modules/`
+
+#### Scenario: Deploy skips providers with disabled ignore
+- **WHEN** `[providers.opencode.ignore]` has `disabled = true`
+- **THEN** the system SHALL NOT write an ignore file for opencode
+
+#### Scenario: Deploy creates parent directories for ignore files
+- **WHEN** an ignore file target path includes nested directories
+- **THEN** the system SHALL create all parent directories before writing the file
+
+### Requirement: Deploy pipeline handles empty patterns
+The system SHALL gracefully handle the case where ignore patterns are defined but the list is empty.
+
+#### Scenario: Empty patterns produces no file
+- **WHEN** `[ignore]` section exists but `patterns = []`
+- **THEN** the deploy pipeline SHALL NOT write any ignore files
+
+#### Scenario: Missing patterns field is treated as empty
+- **WHEN** `[ignore]` section exists but has no `patterns` field
+- **THEN** the deploy pipeline SHALL NOT write any ignore files
+
+### Requirement: Ignore files tracked in gitignore fence
+The system SHALL include deployed ignore file paths in the `.gitignore` fence section managed by dotagents.
+
+#### Scenario: Ignore files added to gitignore fence
+- **WHEN** deploy writes `.ignore` and `.aiignore` files
+- **THEN** `rebuild_fence_from_cache()` SHALL include these paths in the `#region dotagents` section of `.gitignore`
+
+#### Scenario: Undeploy removes ignore files from gitignore fence
+- **WHEN** `dotagents undeploy` is run
+- **THEN** `clear_gitignore_fence()` SHALL remove ignore file paths from the `.gitignore` fence section
+
+### Requirement: Deploy pipeline uses single-phase rendering for ignore
+The system SHALL render ignore templates in a single phase (no two-phase content rendering) since ignore files have no frontmatter or complex structure.
+
+#### Scenario: Single-phase rendering for ignore
+- **WHEN** the deploy pipeline processes the ignore feature
+- **THEN** it SHALL skip the content pre-rendering phase and render the template directly against `var.*` and `ignore.patterns`
+
+#### Scenario: Variables available in ignore templates
+- **WHEN** an ignore template references `{{ var.workspace_exclude }}`
+- **THEN** the rendered output SHALL contain the value of that variable

--- a/openspec/changes/add-provider-ignore-files/specs/deploy-pipeline/spec.md
+++ b/openspec/changes/add-provider-ignore-files/specs/deploy-pipeline/spec.md
@@ -16,14 +16,14 @@ The system SHALL process the `ignore` feature in the deploy pipeline alongside `
 - **THEN** the system SHALL create all parent directories before writing the file
 
 ### Requirement: Deploy pipeline handles empty patterns
-The system SHALL gracefully handle the case where ignore patterns are defined but the list is empty.
+The system SHALL gracefully handle the case where `.agentignore` is empty or missing.
 
-#### Scenario: Empty patterns produces no file
-- **WHEN** `[ignore]` section exists but `patterns = []`
+#### Scenario: Empty .agentignore produces no file
+- **WHEN** `.dotagents/.agentignore` exists but is empty
 - **THEN** the deploy pipeline SHALL NOT write any ignore files
 
-#### Scenario: Missing patterns field is treated as empty
-- **WHEN** `[ignore]` section exists but has no `patterns` field
+#### Scenario: Missing .agentignore produces no file
+- **WHEN** `.dotagents/.agentignore` does not exist
 - **THEN** the deploy pipeline SHALL NOT write any ignore files
 
 ### Requirement: Ignore files tracked in gitignore fence

--- a/openspec/changes/add-provider-ignore-files/specs/ignore-feature/spec.md
+++ b/openspec/changes/add-provider-ignore-files/specs/ignore-feature/spec.md
@@ -38,35 +38,43 @@ The system SHALL provide an `IgnoreFeature` struct that implements `FeatureTrait
 - **WHEN** an `IgnoreFeature` is serialized with `to_string()` then parsed with `from_string()`
 - **THEN** the resulting patterns SHALL be identical to the original
 
-### Requirement: Ignore patterns from config
-The system SHALL load ignore patterns from an `[ignore]` table in `config.toml` with a `patterns` array field.
+### Requirement: Ignore patterns from `.agentignore` file
+The system SHALL load ignore patterns from `.dotagents/.agentignore` — a newline-separated file (one pattern per line), similar to `INSTRUCTIONS.md` and `mcp.jsonc`.
 
-#### Scenario: Load patterns from config
-- **WHEN** `config.toml` contains:
-  ```toml
-  [ignore]
-  patterns = ["node_modules/", "*.log", ".env"]
+#### Scenario: Load patterns from .agentignore
+- **WHEN** `.dotagents/.agentignore` contains:
+  ```
+  node_modules/
+  *.log
+  .env
   ```
 - **THEN** the deploy pipeline SHALL load these patterns into an `IgnoreFeature`
 
-#### Scenario: Empty patterns list is valid
-- **WHEN** `config.toml` contains:
-  ```toml
-  [ignore]
-  patterns = []
-  ```
-- **THEN** the deploy pipeline SHALL load an `IgnoreFeature` with zero patterns (no file written)
+#### Scenario: Missing .agentignore is valid
+- **WHEN** `.dotagents/.agentignore` does not exist
+- **THEN** the deploy pipeline SHALL load an `IgnoreFeature` with zero patterns (no error)
 
-#### Scenario: Missing ignore section is valid
-- **WHEN** `config.toml` has no `[ignore]` table
-- **THEN** the deploy pipeline SHALL skip the ignore feature without error
+#### Scenario: Empty .agentignore is valid
+- **WHEN** `.dotagents/.agentignore` exists but is empty
+- **THEN** the deploy pipeline SHALL load an `IgnoreFeature` with zero patterns
+
+### Requirement: Per-provider ignore disable
+The system SHALL support `[providers.<name>.ignore]` in `config.toml` with `disabled = true/false` to skip ignore file generation for specific providers.
+
+#### Scenario: Provider disables ignore feature
+- **WHEN** `[providers.claude.ignore]` has `disabled = true`
+- **THEN** the deploy pipeline SHALL NOT write any ignore file for the claude provider
+
+#### Scenario: Provider omits ignore section
+- **WHEN** a provider has no `[providers.<name>.ignore]` section
+- **THEN** the deploy pipeline SHALL write the ignore file using patterns from `.agentignore`
 
 ### Requirement: Ignore feature in Features config struct
 The system SHALL add an `ignore: Option<FeatureSettings>` field to the `Features` struct in `src/core/config/common.rs`.
 
 #### Scenario: Features struct includes ignore field
 - **WHEN** a `Features` struct is serialized to TOML
-- **THEN** it SHALL include an `[ignore]` section if `ignore` is `Some`
+- **THEN** it SHALL include an `[features.ignore]` section if `ignore` is `Some`
 
 #### Scenario: Features::get_config returns ignore settings
 - **WHEN** `get_config(&Feature::Ignore)` is called on a `Features` instance

--- a/openspec/changes/add-provider-ignore-files/specs/ignore-feature/spec.md
+++ b/openspec/changes/add-provider-ignore-files/specs/ignore-feature/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Ignore feature type
+The system SHALL support an `ignore` feature type alongside `commands`, `instructions`, `mcp`, and `skills`. The feature SHALL be identified by the string `"ignore"` in config files and the deploy pipeline.
+
+#### Scenario: Feature enum includes Ignore variant
+- **WHEN** the `Feature` enum is constructed
+- **THEN** it SHALL include a `Feature::Ignore` variant that maps to `"ignore"` in config files
+
+#### Scenario: Feature parsing recognizes "ignore"
+- **WHEN** `Feature::from_str("ignore")` is called
+- **THEN** it SHALL return `Some(Feature::Ignore)`
+
+#### Scenario: Feature::all() includes Ignore
+- **WHEN** `Feature::all()` is called
+- **THEN** the returned array SHALL include `Feature::Ignore`
+
+### Requirement: IgnoreFeature implements FeatureTrait
+The system SHALL provide an `IgnoreFeature` struct that implements `FeatureTrait` for handling ignore pattern lists.
+
+#### Scenario: IgnoreFeature holds a list of patterns
+- **WHEN** an `IgnoreFeature` is created with patterns `["node_modules/", "*.log", ".env"]`
+- **THEN** `to_value()` SHALL return a JSON object with an `ignore.patterns` array containing those strings
+
+#### Scenario: IgnoreFeature serializes to newline-separated patterns
+- **WHEN** `to_string()` is called on an `IgnoreFeature` with patterns `["node_modules/", "*.log"]`
+- **THEN** the output SHALL be `"node_modules/\n*.log\n"` (one pattern per line, trailing newline)
+
+#### Scenario: IgnoreFeature deserializes from newline-separated patterns
+- **WHEN** `from_string("node_modules/\n*.log\n")` is called
+- **THEN** the resulting `IgnoreFeature` SHALL have patterns `["node_modules/", "*.log"]`
+
+#### Scenario: IgnoreFeature returns None for get_file_name
+- **WHEN** `get_file_name()` is called on an `IgnoreFeature`
+- **THEN** it SHALL return `None` (singleton feature, one file per provider)
+
+#### Scenario: IgnoreFeature roundtrip preserves patterns
+- **WHEN** an `IgnoreFeature` is serialized with `to_string()` then parsed with `from_string()`
+- **THEN** the resulting patterns SHALL be identical to the original
+
+### Requirement: Ignore patterns from config
+The system SHALL load ignore patterns from an `[ignore]` table in `config.toml` with a `patterns` array field.
+
+#### Scenario: Load patterns from config
+- **WHEN** `config.toml` contains:
+  ```toml
+  [ignore]
+  patterns = ["node_modules/", "*.log", ".env"]
+  ```
+- **THEN** the deploy pipeline SHALL load these patterns into an `IgnoreFeature`
+
+#### Scenario: Empty patterns list is valid
+- **WHEN** `config.toml` contains:
+  ```toml
+  [ignore]
+  patterns = []
+  ```
+- **THEN** the deploy pipeline SHALL load an `IgnoreFeature` with zero patterns (no file written)
+
+#### Scenario: Missing ignore section is valid
+- **WHEN** `config.toml` has no `[ignore]` table
+- **THEN** the deploy pipeline SHALL skip the ignore feature without error
+
+### Requirement: Ignore feature in Features config struct
+The system SHALL add an `ignore: Option<FeatureSettings>` field to the `Features` struct in `src/core/config/common.rs`.
+
+#### Scenario: Features struct includes ignore field
+- **WHEN** a `Features` struct is serialized to TOML
+- **THEN** it SHALL include an `[ignore]` section if `ignore` is `Some`
+
+#### Scenario: Features::get_config returns ignore settings
+- **WHEN** `get_config(&Feature::Ignore)` is called on a `Features` instance
+- **THEN** it SHALL return the `ignore` field value
+
+#### Scenario: Features::merge includes ignore
+- **WHEN** two `Features` instances are merged
+- **THEN** the `ignore` field SHALL be merged using the same logic as other features
+
+### Requirement: Ignore feature gated by features list
+The system SHALL only deploy the ignore feature when `"ignore"` is listed in the `features` array of `config.toml`.
+
+#### Scenario: Deploy ignore when feature is enabled
+- **WHEN** `features = ["commands", "ignore"]` in `config.toml`
+- **THEN** the deploy pipeline SHALL process the ignore feature
+
+#### Scenario: Skip deploy when feature is not listed
+- **WHEN** `features = ["commands", "instructions"]` in `config.toml`
+- **THEN** the deploy pipeline SHALL NOT attempt to load or deploy ignore patterns
+
+### Requirement: Ignore feature can be disabled per-provider
+The system SHALL respect `disabled = true` in `[providers.<name>.ignore]` to skip ignore file generation for specific providers.
+
+#### Scenario: Provider disables ignore feature
+- **WHEN** `[providers.claude.ignore]` has `disabled = true`
+- **THEN** the deploy pipeline SHALL NOT write an ignore file for the claude provider
+
+#### Scenario: Provider enables ignore by default
+- **WHEN** a provider has no `disabled` setting for ignore
+- **THEN** the deploy pipeline SHALL write the ignore file if patterns exist

--- a/openspec/changes/add-provider-ignore-files/specs/ignore-init-scaffold/spec.md
+++ b/openspec/changes/add-provider-ignore-files/specs/ignore-init-scaffold/spec.md
@@ -22,23 +22,19 @@ The TUI init wizard SHALL present "Ignore Patterns" as a selectable feature in t
 - **WHEN** the TUI feature multiselect is displayed
 - **THEN** "Ignore Patterns" SHALL be pre-selected alongside "Custom Commands", "INSTRUCTIONS.md", and "MCP Configuration"
 
-### Requirement: Init scaffolds ignore patterns file
-The system SHALL create a default ignore patterns file in `.dotagents/` when the ignore feature is selected during `init`.
+### Requirement: Init scaffolds `.agentignore` file
+The system SHALL create a default `.dotagents/.agentignore` file when the ignore feature is selected during `init`.
 
-#### Scenario: Init creates ignore file when feature is enabled
+#### Scenario: Init creates .agentignore when feature is enabled
 - **WHEN** `dotagents init --features commands,ignore` is run
-- **THEN** a default ignore patterns file SHALL be created at `.dotagents/ignore`
+- **THEN** a default ignore patterns file SHALL be created at `.dotagents/.agentignore`
 
-#### Scenario: Init skips ignore file when feature is not selected
+#### Scenario: Init skips .agentignore when feature is not selected
 - **WHEN** `dotagents init --features commands,instructions` is run
-- **THEN** no ignore patterns file SHALL be created
+- **THEN** no `.agentignore` file SHALL be created
 
-#### Scenario: Init with --no-ignore flag skips ignore file
-- **WHEN** `dotagents init --no-ignore` is run
-- **THEN** no ignore patterns file SHALL be created
-
-#### Scenario: Default ignore file contains common patterns
-- **WHEN** the default ignore file is created during init
+#### Scenario: Default .agentignore contains common patterns
+- **WHEN** the default `.agentignore` file is created during init
 - **THEN** it SHALL contain common patterns: `node_modules/`, `.git/`, `target/`, `.env`
 
 ### Requirement: Default ignore patterns mock content
@@ -49,7 +45,7 @@ The system SHALL embed default ignore patterns as a compile-time mock string, so
 - **THEN** it SHALL be a valid newline-separated list of glob patterns
 
 ### Requirement: InitOptions supports ignore feature flag
-The `InitOptions` struct SHALL support the ignore feature in the `--features` flag and provide a `--no-ignore` convenience flag.
+The `InitOptions` struct SHALL support the ignore feature in the `--features` flag.
 
 #### Scenario: --features accepts ignore
 - **WHEN** `dotagents init --features ignore` is run

--- a/openspec/changes/add-provider-ignore-files/specs/ignore-init-scaffold/spec.md
+++ b/openspec/changes/add-provider-ignore-files/specs/ignore-init-scaffold/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Ignore feature in init Feature enum
+The system SHALL include an `Ignore` variant in the `Feature` enum used by `dotagents init` for feature selection.
+
+#### Scenario: Feature enum includes Ignore variant
+- **WHEN** the `Feature` enum is used in `dotagents init --features`
+- **THEN** it SHALL accept `ignore` as a valid feature value
+
+#### Scenario: Feature::as_str returns "ignore"
+- **WHEN** `Feature::Ignore.as_str()` is called
+- **THEN** it SHALL return `"ignore"`
+
+### Requirement: TUI init wizard includes ignore feature
+The TUI init wizard SHALL present "Ignore Patterns" as a selectable feature in the multiselect prompt.
+
+#### Scenario: Ignore appears in TUI feature selection
+- **WHEN** the TUI init wizard displays the feature multiselect
+- **THEN** it SHALL include an item labeled "Ignore Patterns" with description "Sync ignore patterns to AI tools"
+
+#### Scenario: Ignore is pre-selected by default
+- **WHEN** the TUI feature multiselect is displayed
+- **THEN** "Ignore Patterns" SHALL be pre-selected alongside "Custom Commands", "INSTRUCTIONS.md", and "MCP Configuration"
+
+### Requirement: Init scaffolds ignore patterns file
+The system SHALL create a default ignore patterns file in `.dotagents/` when the ignore feature is selected during `init`.
+
+#### Scenario: Init creates ignore file when feature is enabled
+- **WHEN** `dotagents init --features commands,ignore` is run
+- **THEN** a default ignore patterns file SHALL be created at `.dotagents/ignore`
+
+#### Scenario: Init skips ignore file when feature is not selected
+- **WHEN** `dotagents init --features commands,instructions` is run
+- **THEN** no ignore patterns file SHALL be created
+
+#### Scenario: Init with --no-ignore flag skips ignore file
+- **WHEN** `dotagents init --no-ignore` is run
+- **THEN** no ignore patterns file SHALL be created
+
+#### Scenario: Default ignore file contains common patterns
+- **WHEN** the default ignore file is created during init
+- **THEN** it SHALL contain common patterns: `node_modules/`, `.git/`, `target/`, `.env`
+
+### Requirement: Default ignore patterns mock content
+The system SHALL embed default ignore patterns as a compile-time mock string, sourced from a mock file.
+
+#### Scenario: Mock content is valid newline-separated patterns
+- **WHEN** the default ignore mock content is read
+- **THEN** it SHALL be a valid newline-separated list of glob patterns
+
+### Requirement: InitOptions supports ignore feature flag
+The `InitOptions` struct SHALL support the ignore feature in the `--features` flag and provide a `--no-ignore` convenience flag.
+
+#### Scenario: --features accepts ignore
+- **WHEN** `dotagents init --features ignore` is run
+- **THEN** the `InitOptions.features` field SHALL contain `Feature::Ignore`
+
+#### Scenario: has_feature returns true for ignore
+- **WHEN** `InitOptions.has_feature(Feature::Ignore)` is called with ignore in the features list
+- **THEN** it SHALL return `true`

--- a/openspec/changes/add-provider-ignore-files/specs/ignore-provider-templates/spec.md
+++ b/openspec/changes/add-provider-ignore-files/specs/ignore-provider-templates/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: Provider ignore templates
+The system SHALL provide `ignore.hbs` Handlebars templates for all 20 providers. Templates SHALL render patterns as newline-separated entries.
+
+#### Scenario: Template renders patterns as lines
+- **WHEN** an `ignore.hbs` template is rendered with patterns `["node_modules/", "*.log"]`
+- **THEN** the output SHALL contain each pattern on its own line
+
+#### Scenario: Template supports variable interpolation
+- **WHEN** a template references `{{ var.custom_pattern }}`
+- **THEN** the rendered output SHALL substitute the variable value
+
+### Requirement: Provider.toml includes ignore feature settings
+Each provider SHALL have an `[providers.<slug>.ignore]` section in its `provider.toml` with `template` and `target` fields.
+
+#### Scenario: Opencode provider has ignore config
+- **WHEN** the opencode provider.toml is parsed
+- **THEN** it SHALL include `[providers.opencode.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.ignore`
+
+#### Scenario: Auggie provider has ignore config
+- **WHEN** the auggie provider.toml is parsed
+- **THEN** it SHALL include `[providers.auggie.ignore]` with `target` resolving to `{{ dir.workspace }}/.augmentignore`
+
+#### Scenario: Autohand provider has ignore config
+- **WHEN** the autohand provider.toml is parsed
+- **THEN** it SHALL include `[providers.autohand.ignore]` with `target` resolving to `{{ dir.workspace }}/.autohandignore`
+
+#### Scenario: Junie provider has ignore config
+- **WHEN** the junie provider.toml is parsed
+- **THEN** it SHALL include `[providers.junie.ignore]` with `target` resolving to `{{ dir.workspace }}/.aiignore`
+
+#### Scenario: Pi provider has ignore config
+- **WHEN** the pi provider.toml is parsed
+- **THEN** it SHALL include `[providers.pi.ignore]` with `target` resolving to `{{ dir.workspace }}/.piignore`
+
+#### Scenario: Goose provider has ignore config
+- **WHEN** the goose provider.toml is parsed
+- **THEN** it SHALL include `[providers.goose.ignore]` with `target` resolving to `{{ dir.workspace }}/.gooseignore`
+
+#### Scenario: Cline provider has ignore config
+- **WHEN** the cline provider.toml is parsed
+- **THEN** it SHALL include `[providers.cline.ignore]` with `target` resolving to `{{ dir.workspace }}/.clineignore`
+
+#### Scenario: Gemini provider has ignore config
+- **WHEN** the gemini provider.toml is parsed
+- **THEN** it SHALL include `[providers.gemini.ignore]` with `target` resolving to `{{ dir.workspace }}/.geminiignore`
+
+#### Scenario: Qwen provider has ignore config
+- **WHEN** the qwen provider.toml is parsed
+- **THEN** it SHALL include `[providers.qwen.ignore]` with `target` resolving to `{{ dir.workspace }}/.qwenignore`
+
+#### Scenario: Kilocode provider has ignore config
+- **WHEN** the kilocode provider.toml is parsed
+- **THEN** it SHALL include `[providers.kilocode.ignore]` with `target` resolving to `{{ dir.workspace }}/.kilocodeignore`
+
+#### Scenario: Cursor provider has ignore config
+- **WHEN** the cursor provider.toml is parsed
+- **THEN** it SHALL include `[providers.cursor.ignore]` with `target` resolving to `{{ dir.workspace }}/.cursorignore`
+
+#### Scenario: Claude provider has ignore config
+- **WHEN** the claude provider.toml is parsed
+- **THEN** it SHALL include `[providers.claude.ignore]` with `target` resolving to `{{ dir.workspace }}/.claudeignore`
+
+#### Scenario: Copilot provider has ignore config
+- **WHEN** the copilot provider.toml is parsed
+- **THEN** it SHALL include `[providers.copilot.ignore]` with `target` resolving to `{{ dir.workspace }}/.github/copilotignore`
+
+#### Scenario: Codex provider has ignore config
+- **WHEN** the codex provider.toml is parsed
+- **THEN** it SHALL include `[providers.codex.ignore]` with `target` resolving to `{{ dir.workspace }}/.codexignore`
+
+#### Scenario: Factory-droid provider has ignore config
+- **WHEN** the factory-droid provider.toml is parsed
+- **THEN** it SHALL include `[providers.factory-droid.ignore]` with `target` resolving to `{{ dir.workspace }}/.factoryignore`
+
+#### Scenario: Deepagents provider has ignore config
+- **WHEN** the deepagents provider.toml is parsed
+- **THEN** it SHALL include `[providers.deepagents.ignore]` with `target` resolving to `{{ dir.workspace }}/.deepagentsignore`
+
+#### Scenario: Kimi provider has ignore config
+- **WHEN** the kimi provider.toml is parsed
+- **THEN** it SHALL include `[providers.kimi.ignore]` with `target` resolving to `{{ dir.workspace }}/.kimiignore`
+
+#### Scenario: Mistral-vibe provider has ignore config
+- **WHEN** the mistral-vibe provider.toml is parsed
+- **THEN** it SHALL include `[providers.mistral-vibe.ignore]` with `target` resolving to `{{ dir.workspace }}/.mistralignore`
+
+#### Scenario: Qoder-cli provider has ignore config
+- **WHEN** the qoder-cli provider.toml is parsed
+- **THEN** it SHALL include `[providers.qoder-cli.ignore]` with `target` resolving to `{{ dir.workspace }}/.qoderignore`
+
+#### Scenario: Amp provider has ignore config
+- **WHEN** the amp provider.toml is parsed
+- **THEN** it SHALL include `[providers.amp.ignore]` with `target` resolving to `{{ dir.workspace }}/.ampignore`
+
+### Requirement: Registry includes ignore template checksums
+The system SHALL update `registry.json` with SHA-256 checksums for all new `ignore.hbs` template files.
+
+#### Scenario: Registry entry includes ignore.hbs checksum
+- **WHEN** the registry is generated after adding ignore templates
+- **THEN** each provider's `checksums` map SHALL include an `"ignore.hbs"` key with its SHA-256 hash
+
+### Requirement: Ignore templates follow provider-specific formats
+Each provider's ignore template SHALL render patterns in the format expected by that provider.
+
+#### Scenario: All providers use newline-separated glob patterns
+- **WHEN** any provider's ignore template is rendered
+- **THEN** the output SHALL be newline-separated glob patterns (standard gitignore-like format)

--- a/openspec/changes/add-provider-ignore-files/specs/ignore-provider-templates/spec.md
+++ b/openspec/changes/add-provider-ignore-files/specs/ignore-provider-templates/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Provider ignore templates
-The system SHALL provide `ignore.hbs` Handlebars templates for all 20 providers. Templates SHALL render patterns as newline-separated entries.
+The system SHALL provide `ignore.hbs` Handlebars templates for all supported providers. Templates SHALL render patterns as newline-separated entries.
 
 #### Scenario: Template renders patterns as lines
 - **WHEN** an `ignore.hbs` template is rendered with patterns `["node_modules/", "*.log"]`
@@ -20,79 +20,79 @@ Each provider SHALL have an `[providers.<slug>.ignore]` section in its `provider
 
 #### Scenario: Auggie provider has ignore config
 - **WHEN** the auggie provider.toml is parsed
-- **THEN** it SHALL include `[providers.auggie.ignore]` with `target` resolving to `{{ dir.workspace }}/.augmentignore`
+- **THEN** it SHALL include `[providers.auggie.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.augmentignore`
 
 #### Scenario: Autohand provider has ignore config
 - **WHEN** the autohand provider.toml is parsed
-- **THEN** it SHALL include `[providers.autohand.ignore]` with `target` resolving to `{{ dir.workspace }}/.autohandignore`
+- **THEN** it SHALL include `[providers.autohand.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.autohandignore`
 
 #### Scenario: Junie provider has ignore config
 - **WHEN** the junie provider.toml is parsed
-- **THEN** it SHALL include `[providers.junie.ignore]` with `target` resolving to `{{ dir.workspace }}/.aiignore`
+- **THEN** it SHALL include `[providers.junie.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.aiignore`
 
 #### Scenario: Pi provider has ignore config
 - **WHEN** the pi provider.toml is parsed
-- **THEN** it SHALL include `[providers.pi.ignore]` with `target` resolving to `{{ dir.workspace }}/.piignore`
+- **THEN** it SHALL include `[providers.pi.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.piignore`
 
 #### Scenario: Goose provider has ignore config
 - **WHEN** the goose provider.toml is parsed
-- **THEN** it SHALL include `[providers.goose.ignore]` with `target` resolving to `{{ dir.workspace }}/.gooseignore`
+- **THEN** it SHALL include `[providers.goose.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.gooseignore`
 
 #### Scenario: Cline provider has ignore config
 - **WHEN** the cline provider.toml is parsed
-- **THEN** it SHALL include `[providers.cline.ignore]` with `target` resolving to `{{ dir.workspace }}/.clineignore`
+- **THEN** it SHALL include `[providers.cline.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.clineignore`
 
 #### Scenario: Gemini provider has ignore config
 - **WHEN** the gemini provider.toml is parsed
-- **THEN** it SHALL include `[providers.gemini.ignore]` with `target` resolving to `{{ dir.workspace }}/.geminiignore`
+- **THEN** it SHALL include `[providers.gemini.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.geminiignore`
 
 #### Scenario: Qwen provider has ignore config
 - **WHEN** the qwen provider.toml is parsed
-- **THEN** it SHALL include `[providers.qwen.ignore]` with `target` resolving to `{{ dir.workspace }}/.qwenignore`
+- **THEN** it SHALL include `[providers.qwen.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.qwenignore`
 
 #### Scenario: Kilocode provider has ignore config
 - **WHEN** the kilocode provider.toml is parsed
-- **THEN** it SHALL include `[providers.kilocode.ignore]` with `target` resolving to `{{ dir.workspace }}/.kilocodeignore`
+- **THEN** it SHALL include `[providers.kilocode.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.kilocodeignore`
 
 #### Scenario: Cursor provider has ignore config
 - **WHEN** the cursor provider.toml is parsed
-- **THEN** it SHALL include `[providers.cursor.ignore]` with `target` resolving to `{{ dir.workspace }}/.cursorignore`
+- **THEN** it SHALL include `[providers.cursor.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.cursorignore`
 
 #### Scenario: Claude provider has ignore config
 - **WHEN** the claude provider.toml is parsed
-- **THEN** it SHALL include `[providers.claude.ignore]` with `target` resolving to `{{ dir.workspace }}/.claudeignore`
+- **THEN** it SHALL include `[providers.claude.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.claudeignore`
 
 #### Scenario: Copilot provider has ignore config
 - **WHEN** the copilot provider.toml is parsed
-- **THEN** it SHALL include `[providers.copilot.ignore]` with `target` resolving to `{{ dir.workspace }}/.github/copilotignore`
+- **THEN** it SHALL include `[providers.copilot.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.github/copilotignore`
 
 #### Scenario: Codex provider has ignore config
 - **WHEN** the codex provider.toml is parsed
-- **THEN** it SHALL include `[providers.codex.ignore]` with `target` resolving to `{{ dir.workspace }}/.codexignore`
+- **THEN** it SHALL include `[providers.codex.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.codexignore`
 
 #### Scenario: Factory-droid provider has ignore config
 - **WHEN** the factory-droid provider.toml is parsed
-- **THEN** it SHALL include `[providers.factory-droid.ignore]` with `target` resolving to `{{ dir.workspace }}/.factoryignore`
+- **THEN** it SHALL include `[providers.factory-droid.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.factoryignore`
 
 #### Scenario: Deepagents provider has ignore config
 - **WHEN** the deepagents provider.toml is parsed
-- **THEN** it SHALL include `[providers.deepagents.ignore]` with `target` resolving to `{{ dir.workspace }}/.deepagentsignore`
+- **THEN** it SHALL include `[providers.deepagents.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.deepagentsignore`
 
 #### Scenario: Kimi provider has ignore config
 - **WHEN** the kimi provider.toml is parsed
-- **THEN** it SHALL include `[providers.kimi.ignore]` with `target` resolving to `{{ dir.workspace }}/.kimiignore`
+- **THEN** it SHALL include `[providers.kimi.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.kimiignore`
 
 #### Scenario: Mistral-vibe provider has ignore config
 - **WHEN** the mistral-vibe provider.toml is parsed
-- **THEN** it SHALL include `[providers.mistral-vibe.ignore]` with `target` resolving to `{{ dir.workspace }}/.mistralignore`
+- **THEN** it SHALL include `[providers.mistral-vibe.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.mistralignore`
 
 #### Scenario: Qoder-cli provider has ignore config
 - **WHEN** the qoder-cli provider.toml is parsed
-- **THEN** it SHALL include `[providers.qoder-cli.ignore]` with `target` resolving to `{{ dir.workspace }}/.qoderignore`
+- **THEN** it SHALL include `[providers.qoder-cli.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.qoderignore`
 
 #### Scenario: Amp provider has ignore config
 - **WHEN** the amp provider.toml is parsed
-- **THEN** it SHALL include `[providers.amp.ignore]` with `target` resolving to `{{ dir.workspace }}/.ampignore`
+- **THEN** it SHALL include `[providers.amp.ignore]` with `template` pointing to `ignore.hbs` and `target` resolving to `{{ dir.workspace }}/.ampignore`
 
 ### Requirement: Registry includes ignore template checksums
 The system SHALL update `registry.json` with SHA-256 checksums for all new `ignore.hbs` template files.

--- a/openspec/changes/add-provider-ignore-files/tasks.md
+++ b/openspec/changes/add-provider-ignore-files/tasks.md
@@ -1,0 +1,65 @@
+## 1. Core Feature Implementation
+
+- [ ] 1.1 Add `Ignore` variant to `Feature` enum in `src/core/features/common.rs`
+- [ ] 1.2 Create `IgnoreFeature` struct in `src/core/features/ignore.rs` implementing `FeatureTrait`
+- [ ] 1.3 Add `ignore` module export in `src/core/features.rs`
+- [ ] 1.4 Add `ignore: Option<FeatureSettings>` to `Features` struct in `src/core/config/common.rs`
+- [ ] 1.5 Update `Features::get_config()` to handle `Feature::Ignore`
+- [ ] 1.6 Update `Features::merge()` to include ignore field
+- [ ] 1.7 Add `[ignore]` config parsing with `patterns` field
+
+## 2. Deploy Pipeline Integration
+
+- [ ] 2.1 Wire ignore feature into deploy pipeline in `src/cli/deploy.rs`
+- [ ] 2.2 Implement single-phase rendering for ignore feature in `src/templates/renderer.rs`
+- [ ] 2.3 Add ignore file paths to gitignore fence tracking in `src/utils/gitignore.rs`
+- [ ] 2.4 Update `AppConfig::has_feature()` to recognize "ignore"
+
+## 3. Provider Templates
+
+- [ ] 3.1 Create `public/v1/templates/opencode/ignore.hbs` with target `.ignore`
+- [ ] 3.2 Create `public/v1/templates/auggie/ignore.hbs` with target `.augmentignore`
+- [ ] 3.3 Create `public/v1/templates/autohand/ignore.hbs` with target `.autohandignore`
+- [ ] 3.4 Create `public/v1/templates/junie/ignore.hbs` with target `.aiignore`
+- [ ] 3.5 Create `public/v1/templates/pi/ignore.hbs` with target `.piignore`
+- [ ] 3.6 Create `public/v1/templates/goose/ignore.hbs` with target `.gooseignore`
+- [ ] 3.7 Create `public/v1/templates/cline/ignore.hbs` with target `.clineignore`
+- [ ] 3.8 Create `public/v1/templates/gemini/ignore.hbs` with target `.geminiignore`
+- [ ] 3.9 Create `public/v1/templates/qwen/ignore.hbs` with target `.qwenignore`
+- [ ] 3.10 Create `public/v1/templates/kilocode/ignore.hbs` with target `.kilocodeignore`
+- [ ] 3.11 Create `public/v1/templates/cursor/ignore.hbs` with target `.cursorignore`
+- [ ] 3.12 Create `public/v1/templates/claude/ignore.hbs` with target `.claudeignore`
+- [ ] 3.13 Create `public/v1/templates/copilot/ignore.hbs` with target `.github/copilotignore`
+- [ ] 3.14 Create `public/v1/templates/codex/ignore.hbs` with target `.codexignore`
+- [ ] 3.15 Create `public/v1/templates/factory-droid/ignore.hbs` with target `.factoryignore`
+- [ ] 3.16 Create `public/v1/templates/deepagents/ignore.hbs` with target `.deepagentsignore`
+- [ ] 3.17 Create `public/v1/templates/kimi/ignore.hbs` with target `.kimiignore`
+- [ ] 3.18 Create `public/v1/templates/mistral-vibe/ignore.hbs` with target `.mistralignore`
+- [ ] 3.19 Create `public/v1/templates/qoder-cli/ignore.hbs` with target `.qoderignore`
+- [ ] 3.20 Create `public/v1/templates/amp/ignore.hbs` with target `.ampignore`
+- [ ] 3.21 Update `provider.toml` for each provider with `[providers.<slug>.ignore]` section
+
+## 4. Init Integration
+
+- [ ] 4.1 Add `Ignore` variant to `Feature` enum in `src/cli/options.rs`
+- [ ] 4.2 Add `Feature::Ignore` → `"ignore"` mapping in `Feature::as_str()`
+- [ ] 4.3 Add "Ignore Patterns" option to TUI init wizard in `src/cli/ui/init.rs` multiselect
+- [ ] 4.4 Add `--no-ignore` flag support in `InitOptions` (parallel to `--no-mcp`, `--no-command`, etc.)
+- [ ] 4.5 Create default ignore patterns mock file in `src/constants/mocks.rs`
+- [ ] 4.6 Wire ignore file scaffolding into `initialize_agents_dir()` in `src/cli/init.rs` with skip condition
+- [ ] 4.7 Add `IGNORE_FILE` constant in `src/constants/file.rs`
+
+## 5. Testing
+
+- [ ] 5.1 Add unit tests for `IgnoreFeature` in `src/core/features/ignore.rs`
+- [ ] 5.2 Add unit tests for config parsing and merging in `src/core/config/common.rs`
+- [ ] 5.3 Add unit tests for init skip conditions with ignore feature
+- [ ] 5.4 Manually test deploy with tui-devtools for all 20 providers
+- [ ] 5.5 Manually test init wizard with ignore feature selected/deselected
+- [ ] 5.6 Add e2e tests for ignore feature deploy flow
+- [ ] 5.7 Add e2e tests for init with `--no-ignore` flag
+
+## 6. Verification
+
+- [ ] 6.1 Run `mise check` (cargo fmt + clippy) — must exit 0
+- [ ] 6.2 Run `mise tests` — must exit 0

--- a/openspec/changes/add-provider-ignore-files/tasks.md
+++ b/openspec/changes/add-provider-ignore-files/tasks.md
@@ -6,7 +6,8 @@
 - [ ] 1.4 Add `ignore: Option<FeatureSettings>` to `Features` struct in `src/core/config/common.rs`
 - [ ] 1.5 Update `Features::get_config()` to handle `Feature::Ignore`
 - [ ] 1.6 Update `Features::merge()` to include ignore field
-- [ ] 1.7 Add `[ignore]` config parsing with `patterns` field
+- [ ] 1.7 Add `.agentignore` file loading (newline-separated patterns from `.dotagents/.agentignore`)
+- [ ] 1.8 Add per-provider `[providers.<name>.ignore].disabled` config parsing
 
 ## 2. Deploy Pipeline Integration
 
@@ -38,26 +39,26 @@
 - [ ] 3.19 Create `public/v1/templates/qoder-cli/ignore.hbs` with target `.qoderignore`
 - [ ] 3.20 Create `public/v1/templates/amp/ignore.hbs` with target `.ampignore`
 - [ ] 3.21 Update `provider.toml` for each provider with `[providers.<slug>.ignore]` section
+- [ ] 3.22 Update provider registry checksums in `registry.json` for all new `ignore.hbs` files
 
 ## 4. Init Integration
 
 - [ ] 4.1 Add `Ignore` variant to `Feature` enum in `src/cli/options.rs`
 - [ ] 4.2 Add `Feature::Ignore` → `"ignore"` mapping in `Feature::as_str()`
 - [ ] 4.3 Add "Ignore Patterns" option to TUI init wizard in `src/cli/ui/init.rs` multiselect
-- [ ] 4.4 Add `--no-ignore` flag support in `InitOptions` (parallel to `--no-mcp`, `--no-command`, etc.)
-- [ ] 4.5 Create default ignore patterns mock file in `src/constants/mocks.rs`
-- [ ] 4.6 Wire ignore file scaffolding into `initialize_agents_dir()` in `src/cli/init.rs` with skip condition
-- [ ] 4.7 Add `IGNORE_FILE` constant in `src/constants/file.rs`
+- [ ] 4.4 Create default `.agentignore` mock file in `src/constants/mocks.rs`
+- [ ] 4.5 Wire `.agentignore` scaffolding into `initialize_agents_dir()` in `src/cli/init.rs`
+- [ ] 4.6 Add `AGENTIGNORE_FILE` constant in `src/constants/file.rs`
 
 ## 5. Testing
 
 - [ ] 5.1 Add unit tests for `IgnoreFeature` in `src/core/features/ignore.rs`
 - [ ] 5.2 Add unit tests for config parsing and merging in `src/core/config/common.rs`
-- [ ] 5.3 Add unit tests for init skip conditions with ignore feature
-- [ ] 5.4 Manually test deploy with tui-devtools for all 20 providers
+- [ ] 5.3 Add unit tests for init with ignore feature selected/deselected
+- [ ] 5.4 Manually test deploy with tui-devtools for all supported providers
 - [ ] 5.5 Manually test init wizard with ignore feature selected/deselected
 - [ ] 5.6 Add e2e tests for ignore feature deploy flow
-- [ ] 5.7 Add e2e tests for init with `--no-ignore` flag
+- [ ] 5.7 Add e2e tests for init with `--features ignore` flag
 
 ## 6. Verification
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design and specification documentation for a new ignore patterns feature, enabling users to configure and automatically deploy provider-specific ignore files during initialization and deployment.
  * Specified requirements for template rendering, per-provider configuration, and integration with the deployment pipeline across 20 supported providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soorya-u/dotagents/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->