### PR TITLE
Remove interactive offline-mode prompt from deploy command

### DIFF
--- a/openspec/specs/deploy-gitignore-update/spec.md
+++ b/openspec/specs/deploy-gitignore-update/spec.md
@@ -62,7 +62,7 @@ When `--no-gitignore` is passed to `dotagents deploy`, the gitignore update step
 - **THEN** `.gitignore` is not modified regardless of what was deployed
 
 ### Requirement: Default mode prompts the user interactively
-When neither `--gitignore` nor `--no-gitignore` is passed, `dotagents deploy` SHALL prompt the user after deploy completes with the count of new paths using a cliclack `select` prompt with `Yes` and `No` options. Default selection is `No`.
+When neither `--gitignore` nor `--no-gitignore` is passed, `dotagents deploy` SHALL prompt the user after deploy completes with the count of collapsed gitignore patterns using a cliclack `select` prompt with `Yes` and `No` options. The count SHALL reflect the number of patterns after the collapse algorithm has run (e.g., 4 files in `.opencode/` collapse to 1 directory pattern), not the raw number of cached target paths. Default selection is `No`.
 
 #### Scenario: User selects Yes — update runs
 - **WHEN** the cliclack select prompt is shown and the user selects `Yes`

--- a/openspec/specs/deploy-offline-prompt/spec.md
+++ b/openspec/specs/deploy-offline-prompt/spec.md
@@ -1,41 +1,34 @@
 ## ADDED Requirements
 
-### Requirement: Offline mode prompt shown at start of deploy in TUI mode
-When `dotagents deploy` runs in TUI mode (TTY, no `--offline` flag), it SHALL display a cliclack `select` prompt asking whether to run in offline mode before the registry-fetch step executes. The prompt SHALL default to `No` (online mode).
+### Requirement: Deploy defaults to online mode
+When `dotagents deploy` runs without the `--offline` flag, it SHALL attempt to fetch the provider registry and resolve templates from the network. No interactive prompt is shown to ask the user about offline mode.
 
-#### Scenario: User selects No — deploy runs online
-- **WHEN** the offline prompt is shown and the user selects `No` or accepts the default
-- **THEN** deploy proceeds with registry fetch enabled (identical to running without `--offline`)
+#### Scenario: Default deploy runs online
+- **WHEN** `dotagents deploy` is run without `--offline`
+- **THEN** deploy proceeds with registry fetch enabled and attempts network resolution
 
-#### Scenario: User selects Yes — deploy runs offline
-- **WHEN** the offline prompt is shown and the user selects `Yes`
-- **THEN** deploy skips the registry fetch, identical to passing `--offline`
+#### Scenario: Network failure falls back to cache
+- **WHEN** deploy runs online but the registry fetch fails
+- **THEN** a warning is logged and deploy falls back to the local template-source cache
 
-#### Scenario: Default selection is No (online)
-- **WHEN** the offline prompt is displayed
-- **THEN** `No` is highlighted as the default option
+#### Scenario: Network failure and cache cold — provider skipped
+- **WHEN** deploy runs online, the registry fetch fails, and no cached `provider.toml` exists for a provider
+- **THEN** a warning is logged identifying the provider as skipped; deploy continues for other providers
 
-### Requirement: --offline flag bypasses the prompt
-When `--offline` is passed to `dotagents deploy`, the offline mode prompt SHALL NOT be shown and deploy SHALL run in offline mode directly.
+### Requirement: --offline flag enables offline mode
+When `--offline` is passed to `dotagents deploy`, deploy SHALL skip the registry fetch and resolve templates from the local template-source cache only.
 
-#### Scenario: --offline flag skips prompt
+#### Scenario: --offline flag skips registry fetch
 - **WHEN** `dotagents deploy --offline` is run
-- **THEN** no offline prompt is shown and the registry fetch is skipped
+- **THEN** no network request is made and resolution uses the cached `provider.toml`
 
 ### Requirement: Non-TTY defaults to online without prompting
-When deploy runs in a non-interactive environment (CI, piped), no offline prompt is shown and online mode is used unless `--offline` is explicitly passed.
+When deploy runs in a non-interactive environment (CI, piped), online mode is used unless `--offline` is explicitly passed.
 
 #### Scenario: Non-TTY online deploy
 - **WHEN** deploy runs with no TTY and no `--offline` flag
-- **THEN** no prompt is shown and deploy proceeds online
+- **THEN** deploy proceeds online
 
 #### Scenario: Non-TTY with --offline flag
 - **WHEN** deploy runs with no TTY and `--offline` is passed
-- **THEN** no prompt is shown and deploy proceeds offline
-
-### Requirement: Offline prompt lives in src/cli/ui/deploy.rs
-The offline mode prompt function SHALL reside in `src/cli/ui/deploy.rs` alongside the gitignore confirmation prompt.
-
-#### Scenario: Module boundary respected
-- **WHEN** the deploy command needs to prompt for offline mode
-- **THEN** it calls into `crate::cli::ui::deploy` for the prompt before the registry-fetch block in `src/cli/deploy.rs`
+- **THEN** deploy proceeds offline

--- a/openspec/specs/deploy-outro/spec.md
+++ b/openspec/specs/deploy-outro/spec.md
@@ -43,11 +43,11 @@ If no providers are configured in the workspace config at deploy time, `dotagent
 - **THEN** no missing-providers warning is emitted
 
 ### Requirement: Deploy is framed with cliclack intro and outro in TTY mode
-When `dotagents deploy` runs interactively, it SHALL open with a cliclack `intro` banner and close with a cliclack `outro` message. The intro SHALL appear before the offline prompt. The outro SHALL appear after the gitignore step completes (or is skipped), at all TTY exit paths. In non-TTY mode neither intro nor outro is printed.
+When `dotagents deploy` runs interactively, it SHALL open with a cliclack `intro` banner and close with a cliclack `outro` message. The intro SHALL appear before the registry fetch. The outro SHALL appear after the gitignore step completes (or is skipped), at all TTY exit paths. In non-TTY mode neither intro nor outro is printed.
 
-#### Scenario: Intro printed before first prompt
+#### Scenario: Intro printed before registry fetch
 - **WHEN** `dotagents deploy` runs in a TTY
-- **THEN** a `┌ …` intro line is printed before the offline mode select prompt
+- **THEN** a `┌ …` intro line is printed before the registry fetch step
 
 #### Scenario: Outro printed after gitignore step
 - **WHEN** deploy completes and the gitignore step finishes (accepted, declined, or skipped)

--- a/openspec/specs/provider-registry-resolution/spec.md
+++ b/openspec/specs/provider-registry-resolution/spec.md
@@ -46,15 +46,15 @@ If `registry.json` cannot be fetched due to a network error and `--offline` has 
 - **THEN** a warning is logged for the registry failure and a second warning is logged identifying the provider/feature as skipped; deploy continues for other providers
 
 ### Requirement: `--offline` flag skips registry fetch and resolves from cache only
-When `dotagents deploy --offline` is specified, `dotagents deploy` SHALL NOT make any network request for registry or template resolution. Missing fields SHALL be resolved from the template-source cache only. If the cache is cold for a required provider/feature, deploy SHALL error with a clear message.
+When `dotagents deploy --offline` is specified, `dotagents deploy` SHALL NOT make any network request for registry or template resolution. Missing fields SHALL be resolved from the template-source cache only. If the cache is cold for a required provider/feature, a warning SHALL be emitted and that provider SHALL be skipped. The deploy SHALL NOT hard-error.
 
 #### Scenario: Offline mode, cache warm — resolves without network
 - **WHEN** `--offline` is passed and the provider's `provider.toml` is in the template-source cache
 - **THEN** no network request is made; resolution uses the cached `provider.toml`; deploy proceeds
 
-#### Scenario: Offline mode, cache cold — hard error
+#### Scenario: Offline mode, cache cold — provider skipped with warning
 - **WHEN** `--offline` is passed and no cached `provider.toml` exists for a provider that requires auto-resolution
-- **THEN** deploy stops with an error identifying the provider and instructing the user to run without `--offline` first to populate the cache
+- **THEN** a warning is logged identifying the provider as skipped and instructing the user to run without `--offline` first to populate the cache; deploy continues for other providers
 
 ### Requirement: Registry entries MAY include name and url display fields
 Each provider entry in `registry.json` MAY include a `name` field (human-readable display label) and a `url` field (documentation hyperlink). Both fields SHALL be strings when present. Absence of these fields SHALL NOT cause parsing failures; the fields are purely additive for display purposes.

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -1,15 +1,13 @@
 use crate::prelude::*;
 use rayon::prelude::*;
 use serde_json::{Value, to_value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use strum::IntoEnumIterator;
 
 use crate::cli::options::DeployOptions;
-use crate::cli::ui::deploy::{
-    deploy_outro, print_deploy_summary, prompt_gitignore_update, prompt_offline,
-};
+use crate::cli::ui::deploy::{deploy_outro, print_deploy_summary, prompt_gitignore_update};
 use crate::cli::ui::dry_run::{
     DeployDryRunStatus, DryRunDeployEntry, print_dry_run_deploy_summary,
 };
@@ -26,10 +24,10 @@ use crate::templates::{
     TemplateCache, Templater, get_templater, registry_url, render_feature_with_settings,
     resolve_provider_defaults, resolve_target_path,
 };
-use crate::utils::gitignore::rebuild_fence_from_cache;
+use crate::utils::gitignore::{collapse_paths, rebuild_fence_from_cache};
 use crate::utils::hash::{hash_content, hash_file};
 use crate::utils::json::merge_json;
-use crate::utils::path::{get_workspace_dir, override_workspace_dir};
+use crate::utils::path::{get_workspace_dir, make_workspace_relative, override_workspace_dir};
 use crate::utils::tui::is_tui_enabled;
 use cliclack::{outro, spinner};
 use std::io::Write;
@@ -395,10 +393,18 @@ fn finalize_deploy(
         return Ok(());
     }
 
+    let relative_paths: Vec<String> = cache_targets
+        .iter()
+        .filter_map(|p| make_workspace_relative(p, &workspace_root))
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    let pattern_count = collapse_paths(&relative_paths, &workspace_root).len();
+
     let should_update = if opts.gitignore {
         true
     } else {
-        stats.written > 0 && prompt_gitignore_update(cache_targets.len())
+        stats.written > 0 && prompt_gitignore_update(pattern_count)
     };
 
     if should_update && let Err(e) = rebuild_fence_from_cache(&cache_targets, &workspace_root) {
@@ -481,10 +487,6 @@ pub(super) fn deploy(mut opts: DeployOptions) -> Result<()> {
     let templater = get_templater().context("unable to initialise templater")?;
     let mut app_config =
         AppConfig::from_application(templater).context("unable to load application config")?;
-
-    if !opts.offline && is_tui_enabled() {
-        opts.offline = prompt_offline();
-    }
 
     let template_cache = TemplateCache::new().context("unable to initialise template cache")?;
     let registry = fetch_registry(opts.offline);

--- a/src/cli/ui/deploy.rs
+++ b/src/cli/ui/deploy.rs
@@ -3,21 +3,6 @@ use cliclack::select;
 use crate::cli::deploy::DeployStats;
 use crate::utils::tui::is_tui_enabled;
 
-/// Prompts whether to run deploy in offline mode using a cliclack select.
-pub(crate) fn prompt_offline() -> bool {
-    if !is_tui_enabled() {
-        return false;
-    }
-    let mut sel = select("Run in offline mode?")
-        .item(false, "No, fetch latest templates", "")
-        .item(
-            true,
-            "Yes, use cached templates only",
-            "skips registry fetch",
-        );
-    sel.interact().unwrap_or(false)
-}
-
 /// Prints deploy completion summary to stdout; in TTY uses `"✓ "` prefix, in non-TTY uses plain text.
 pub(crate) fn print_deploy_summary(stats: &DeployStats) {
     let stdout = std::io::stdout();

--- a/tests/e2e/commands.test.ts
+++ b/tests/e2e/commands.test.ts
@@ -876,10 +876,6 @@ test.describe("commands new TUI – T06 interactive prompts", () => {
 });
 
 // T07: answering Yes to "Deploy now?" triggers deploy.
-// Skipped: the embedded deploy call shows its own offline-mode prompt, making
-// the terminal interaction flow too complex for reliable TUI testing. The
-// deploy functionality is covered by the deploy CLI tests (T15) and journey
-// tests (J07).
 test.describe("commands new TUI – T07 deploy on Yes", () => {
 	const d = makeTmpDir();
 	run(
@@ -916,8 +912,6 @@ test.describe("commands new TUI – T07 deploy on Yes", () => {
 			await expect(terminal.getByText("Deploy now?")).toBeVisible();
 			terminal.keyUp();
 			terminal.keyPress("Enter"); // Yes to deploy
-			await expect(terminal.getByText("Run in offline mode?")).toBeVisible();
-			terminal.keyPress("Enter"); // accept online
 			await expect(
 				terminal.getByText("deployed path(s) to .gitignore?"),
 			).toBeVisible();

--- a/tests/e2e/deploy.test.ts
+++ b/tests/e2e/deploy.test.ts
@@ -292,31 +292,9 @@ test.describe("deploy CLI – CI mode summary", () => {
 // ── TUI flows ────────────────────────────────────────────────────────────────
 // Each TUI test has its own describe block so test.use() is at describe level.
 
-// T14: offline prompt (No) + no-gitignore
-test.describe("deploy TUI – T14 offline prompt", () => {
-	const d = makeTmpDir();
-	initWithLocalProvider(d);
-	test.use({ program: shellProgram(d, ["deploy", "--no-gitignore"]) });
-
-	test("pressing Enter accepts offline=No default", async ({ terminal }) => {
-		try {
-			// offline prompt appears — Enter accepts the default (No = online mode)
-			await expect(terminal.getByText("Run in offline mode?")).toBeVisible();
-			await expect(
-				terminal.getByText("No, fetch latest templates"),
-			).toBeVisible();
-			terminal.keyPress("Enter"); // accept No (online)
-			// Deploy runs silently (no output text to await); just verifying the
-			// prompt appeared and the keypress was accepted without error.
-		} finally {
-			cleanup(d);
-		}
-	});
-});
-
-// T15: --offline flag skips the interactive offline prompt (CLI test, no TUI needed)
-test.describe("deploy CLI – T15 offline flag suppresses prompt", () => {
-	test("--offline flag suppresses offline prompt", async () => {
+// T15: --offline flag uses cached templates (CLI test, no TUI needed)
+test.describe("deploy CLI – T15 offline flag", () => {
+	test("--offline flag deploys from cache", async () => {
 		const d = makeTmpDir();
 		try {
 			initWithLocalProvider(d);
@@ -880,47 +858,16 @@ test.describe("deploy CLI – untrusted URL rejection", () => {
 
 // ── Deploy TUI prompts ───────────────────────────────────────────────────────
 
-// TC-DEPLOY-16: offline prompt Yes selects offline mode
-test.describe("deploy TUI – TC-DEPLOY-16 offline prompt Yes", () => {
-	const d = makeTmpDir();
-	initWithLocalProvider(d);
-	test.use({ program: shellProgram(d, ["deploy"]) });
-
-	test("navigating to Yes on offline prompt enables offline mode", async ({
-		terminal,
-	}) => {
-		try {
-			await expect(terminal.getByText("Run in offline mode?")).toBeVisible();
-			terminal.keyDown();
-			terminal.keyPress("Enter");
-			await expect(
-				terminal.getByText("deployed path(s) to .gitignore?"),
-			).toBeVisible();
-			terminal.keyPress("Enter");
-			await expect(terminal.getByText("written")).toBeVisible();
-			expect(existsSync(join(d, ".mycode/commands/hello.md"))).toBe(true);
-		} finally {
-			cleanup(d);
-		}
-	});
-});
-
 // TC-DEPLOY-01: full TUI deploy journey
 test.describe("deploy TUI – TC-DEPLOY-01 full deploy journey", () => {
 	const d = makeTmpDir();
 	initWithLocalProvider(d);
 	test.use({ program: shellProgram(d, ["deploy"]) });
 
-	test("full interactive deploy: offline No → gitignore No → summary → Done", async ({
+	test("full interactive deploy: gitignore No → summary → Done", async ({
 		terminal,
 	}) => {
 		try {
-			await expect(terminal.getByText("Run in offline mode?")).toBeVisible();
-			await expect(
-				terminal.getByText("No, fetch latest templates"),
-			).toBeVisible();
-			terminal.keyPress("Enter");
-
 			await expect(
 				terminal.getByText("deployed path(s) to .gitignore?"),
 			).toBeVisible();


### PR DESCRIPTION
## Summary

- Removed the interactive `Run in offline mode?` prompt from the deploy TUI flow
- Offline mode is now controlled exclusively via the `--offline` CLI flag
- Gitignore prompt now displays the count of collapsed path patterns instead of raw file count
- Updated and consolidated deploy TUI tests to reflect the simplified flow

## Testing

- Verified `deploy` runs without showing the offline prompt in TUI mode
- Verified `--offline` flag still deploys from cached templates
- Verified full TUI deploy journey: gitignore prompt → summary output → Done
- Verified CI/non-TUI deploy output is unchanged
- `npm run test:e2e` passed for affected deploy tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified the deployment flow by removing the offline mode prompt during interactive deployment.
  * The `--offline` flag remains available for CLI-based offline deployments.
  * Updated test coverage to reflect the streamlined deployment workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soorya-u/dotagents/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->