### PR TITLE
Fail CI deploy on user-edited target files

### DIFF
--- a/openspec/changes/archive/2026-06-20-ci-edited-files-error/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-20-ci-edited-files-error/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/archive/2026-06-20-ci-edited-files-error/design.md
+++ b/openspec/changes/archive/2026-06-20-ci-edited-files-error/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Currently, when `dotagents deploy` detects user-edited target files (on-disk hash differs from cached hash, rendered hash matches cached hash), it:
+
+1. Emits `warn!("Target file {} was manually edited; skipping", path)` per file (`src/templates/renderer.rs:199-202`)
+2. Returns `CacheUpdate::UserEditedSkipped { path }` which is counted as `skipped` in `DeployStats` (`src/cli/deploy.rs:153-156`)
+3. Deploy completes successfully with exit code 0
+
+In CI (non-TTY), this means the pipeline passes silently even though files were not updated. The individual file paths in warnings clutter the log without providing actionable information in a non-interactive context.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- In CI/non-TTY mode, fail deploy (exit 1) when user-edited files are detected without `--force`
+- Show a concise summary error with count of edited files, not individual paths
+- Suggest `--force` as the override mechanism in the error message
+- Preserve existing TTY behavior (per-file warnings, exit 0)
+
+**Non-Goals:**
+
+- Changing the behavior of `--force` (it already overrides user-edit detection)
+- Changing merge-skip behavior (different concern)
+- Adding a new CLI flag for this behavior (CI mode detection is sufficient)
+
+## Decisions
+
+### Decision 1: Track user-edited count in DeployStats
+
+Add a `user_edited: usize` field to `DeployStats`. In `process_cache_update`, when `CacheUpdate::UserEditedSkipped` is encountered, increment `user_edited` in addition to `skipped`.
+
+**Rationale**: The count is already implicitly tracked via `skipped`, but conflating "unchanged" skips with "user-edited" skips makes it impossible to distinguish at finalization time. A dedicated counter is the minimal change.
+
+**Alternative considered**: Collecting edited paths in a `Vec<PathBuf>` on `DeployStats`. Rejected because the proposal explicitly says not to list files — we only need the count, and storing paths would tempt future display.
+
+### Decision 2: Check at finalization, not at detection time
+
+The error check happens in `finalize_deploy` (or just before it), not in the renderer or `process_cache_update`.
+
+**Rationale**: The deploy pipeline uses `rayon::par_iter` — returning an error mid-iteration would short-circuit other work items. We want to deploy everything we can (including non-edited files) and then fail at the end with the total count. This is consistent with the existing "collect stats, then summarize" pattern.
+
+### Decision 3: Gate on non-TTY, not on `--ci` flag
+
+Use `!is_tui_enabled()` (which checks both `--ci` flag and TTY state) rather than checking only the `--ci` flag.
+
+**Rationale**: Non-TTY environments (piped output, CI runners) should all get the concise error behavior. The `is_tui_enabled()` function already encapsulates this logic and is used throughout the codebase for TTY-vs-non-TTY branching.
+
+### Decision 4: Downgrade per-file warn to debug in all modes
+
+Change `warn!("Target file {} was manually edited; skipping")` to `debug!(...)` regardless of TTY mode. The summary message replaces it in both modes.
+
+**Rationale**: In TTY mode, the deploy summary already shows skip counts. Adding a "N files edited" line to the summary is cleaner than per-file warnings. In non-TTY mode, the error summary replaces the warnings entirely. This keeps the change simple — one code path for the per-file log level.
+
+## Risks / Trade-offs
+
+- **TTY users lose per-file visibility** → Mitigation: The summary message includes the count, and `debug!` output is available with `-v`. Users who need per-file detail can add the flag.
+- **CI pipelines that previously passed will start failing** → This is the intended behavior — those pipelines were silently incomplete. The error message clearly indicates `--force` as the fix.

--- a/openspec/changes/archive/2026-06-20-ci-edited-files-error/proposal.md
+++ b/openspec/changes/archive/2026-06-20-ci-edited-files-error/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+When `dotagents deploy` runs in CI and encounters user-edited target files (files whose on-disk content diverges from the cached hash), it currently emits a per-file `warn!` listing each file path and exits 0 (success). In CI this is unhelpful: the individual file paths clutter the log, and the zero exit code means the CI pipeline silently passes even though deploy was incomplete. CI should fail fast with a concise summary instead.
+
+## What Changes
+
+- In CI mode (non-TTY), when user-edited files are detected and `--force` is not passed, deploy SHALL exit with status 1 instead of 0.
+- The per-file `warn!("Target file {} was manually edited; skipping")` SHALL be replaced with a debug-level log per file and a single summary error at the end: e.g. `"3 file(s) were manually edited. Use --force to override."`.
+- In TTY mode, behavior remains unchanged: per-file warnings are shown and deploy exits 0 (the user can see and act on the warnings interactively).
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `deploy-output-cache`: The "Detect and preserve user-edited target files" requirement changes — in CI mode, user-edited files cause a non-zero exit and a summary error instead of per-file warnings with a zero exit.
+- `ci-mode`: CI mode gains an additional behavior — deploy exits 1 when user-edited files are detected without `--force`.
+
+## Impact
+
+- `src/templates/renderer.rs`: Per-file `warn!` for user-edited files downgraded to `debug!`.
+- `src/cli/deploy.rs`: `process_cache_update` needs to track user-edited skip count; `finalize_deploy` (or the deploy entry point) needs to check the count in CI mode and return an error.
+- `src/cli/ui/deploy.rs`: Summary output needs a new "edited files" error line.
+- E2E tests: new CI-mode deploy test asserting exit code 1 and summary message when edited files exist.

--- a/openspec/changes/archive/2026-06-20-ci-edited-files-error/specs/ci-mode/spec.md
+++ b/openspec/changes/archive/2026-06-20-ci-edited-files-error/specs/ci-mode/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: CI deploy fails on user-edited files
+When `dotagents deploy` runs in CI mode (non-TTY) and detects user-edited target files without `--force`, it SHALL exit with status 1 and display a concise error message with the count of edited files. Individual file paths SHALL NOT be listed in the error output.
+
+#### Scenario: CI deploy exits 1 when edited files detected
+- **WHEN** `dotagents deploy` runs in non-TTY mode, at least one target file was manually edited, and `--force` is not passed
+- **THEN** the process SHALL exit with status 1
+
+#### Scenario: CI deploy error message shows count not paths
+- **WHEN** `dotagents deploy` exits with status 1 due to user-edited files in non-TTY mode
+- **THEN** the error output SHALL state the number of edited files and suggest `--force` to override, without listing individual file paths
+
+#### Scenario: CI deploy with --force exits 0 despite edited files
+- **WHEN** `dotagents deploy --force` runs in non-TTY mode and target files were manually edited
+- **THEN** the process SHALL exit with status 0 after overwriting all files

--- a/openspec/changes/archive/2026-06-20-ci-edited-files-error/specs/deploy-output-cache/spec.md
+++ b/openspec/changes/archive/2026-06-20-ci-edited-files-error/specs/deploy-output-cache/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Detect and preserve user-edited target files
+When the stored hash indicates the file should be unchanged but the on-disk content has diverged (user manually edited the target), `dotagents deploy` SHALL skip writing the file and track it as user-edited. In non-TTY (CI) mode, the presence of any user-edited files without `--force` SHALL cause deploy to exit with status 1 and display a summary error with the count of edited files. In TTY mode, deploy SHALL exit with status 0 and display the count in the summary.
+
+#### Scenario: User-edited file — skip and count
+- **WHEN** the rendered output hash matches the stored cache hash but the target file content does not match the stored hash
+- **THEN** deploy SHALL skip writing the file, emit a debug-level log identifying the file path, increment the user-edited counter, and continue to the next item
+
+#### Scenario: Non-TTY deploy fails on user-edited files
+- **WHEN** deploy runs in non-TTY mode (CI), one or more files were manually edited, and `--force` is not passed
+- **THEN** deploy SHALL exit with status 1 and display an error message stating the number of files that were manually edited and suggesting `--force` to override
+
+#### Scenario: Non-TTY deploy with --force succeeds despite edited files
+- **WHEN** deploy runs in non-TTY mode (CI) with `--force` and target files have been manually edited
+- **THEN** the files SHALL be overwritten with the rendered output, cache entries SHALL be updated, and deploy SHALL exit with status 0
+
+#### Scenario: TTY deploy succeeds with edited file count in summary
+- **WHEN** deploy runs in TTY mode and one or more files were manually edited without `--force`
+- **THEN** deploy SHALL exit with status 0 and the summary SHALL include the count of user-edited files
+
+#### Scenario: Force flag overrides user-edit skip
+- **WHEN** `--force` is passed and a target file has been manually edited
+- **THEN** the file is overwritten with the rendered output and the cache entry is updated

--- a/openspec/changes/archive/2026-06-20-ci-edited-files-error/tasks.md
+++ b/openspec/changes/archive/2026-06-20-ci-edited-files-error/tasks.md
@@ -1,0 +1,35 @@
+## 1. Track user-edited count in DeployStats
+
+- [x] 1.1 Add `user_edited: usize` field to `DeployStats` in `src/cli/deploy.rs`
+- [x] 1.2 In `process_cache_update`, increment `stats.user_edited` when handling `CacheUpdate::UserEditedSkipped`
+
+## 2. Downgrade per-file warning to debug
+
+- [x] 2.1 Change `warn!("Target file {} was manually edited; skipping")` to `debug!(...)` in `src/templates/renderer.rs:199-202`
+
+## 3. Fail deploy in CI when user-edited files exist
+
+- [x] 3.1 In `finalize_deploy` (`src/cli/ui/deploy.rs`), after printing summary, check `stats.user_edited > 0 && !is_tui_enabled()` and return `Err` with message like `"N file(s) were manually edited. Use --force to override."`
+- [x] 3.2 Update `finalize_deploy` signature to accept `force: bool` (already available via `opts.force`) so the check can be gated on `!opts.force`
+
+## 4. Update deploy summary output
+
+- [x] 4.1 Add edited count to `write_summary` in `src/cli/ui/deploy.rs` — show `"N edited"` alongside written/skipped when `user_edited > 0`
+- [x] 4.2 Update `deploy_outro` to include edited count for TTY mode
+
+## 5. Unit tests
+
+- [x] 5.1 Add unit test for `write_summary` with `user_edited > 0` in non-TTY mode
+- [x] 5.2 Add unit test for `write_summary` with `user_edited > 0` in TTY mode
+- [x] 5.3 Add unit test verifying `process_cache_update` increments `user_edited` on `UserEditedSkipped`
+
+## 6. E2E tests
+
+- [x] 6.1 Run tui-devtools discovery pass for deploy with user-edited files in CI mode
+- [x] 6.2 Add E2E test: non-TTY deploy with edited files exits 1 and shows count (not paths) in error message
+- [x] 6.3 Add E2E test: non-TTY deploy with `--force` exits 0 despite edited files
+
+## 7. Verification
+
+- [x] 7.1 Run `mise check` (fmt + clippy) and fix any issues
+- [x] 7.2 Run `mise tests` and fix any failures

--- a/openspec/specs/ci-mode/spec.md
+++ b/openspec/specs/ci-mode/spec.md
@@ -30,3 +30,18 @@ The CLI SHALL accept a global `--ci` flag on the `Options` struct. When present,
 - **WHEN** user runs `dotagents --ci <any-subcommand>`
 - **THEN** the flag is accepted without error and CI mode is active for that subcommand
 
+### Requirement: CI deploy fails on user-edited files
+When `dotagents deploy` runs in CI mode (non-TTY) and detects user-edited target files without `--force`, it SHALL exit with status 1 and display a concise error message with the count of edited files. Individual file paths SHALL NOT be listed in the error output.
+
+#### Scenario: CI deploy exits 1 when edited files detected
+- **WHEN** `dotagents deploy` runs in non-TTY mode, at least one target file was manually edited, and `--force` is not passed
+- **THEN** the process SHALL exit with status 1
+
+#### Scenario: CI deploy error message shows count not paths
+- **WHEN** `dotagents deploy` exits with status 1 due to user-edited files in non-TTY mode
+- **THEN** the error output SHALL state the number of edited files and suggest `--force` to override, without listing individual file paths
+
+#### Scenario: CI deploy with --force exits 0 despite edited files
+- **WHEN** `dotagents deploy --force` runs in non-TTY mode and target files were manually edited
+- **THEN** the process SHALL exit with status 0 after overwriting all files
+

--- a/openspec/specs/deploy-output-cache/spec.md
+++ b/openspec/specs/deploy-output-cache/spec.md
@@ -20,11 +20,23 @@
 - **THEN** the target file is written and the cache entry is updated
 
 ### Requirement: Detect and preserve user-edited target files
-When the stored hash indicates the file should be unchanged but the on-disk content has diverged (user manually edited the target), `dotagents deploy` SHALL warn and skip rather than overwrite.
+When the stored hash indicates the file should be unchanged but the on-disk content has diverged (user manually edited the target), `dotagents deploy` SHALL skip writing the file and track it as user-edited. In non-TTY (CI) mode, the presence of any user-edited files without `--force` SHALL cause deploy to exit with status 1 and display a summary error with the count of edited files. In TTY mode, deploy SHALL exit with status 0 and display the count in the summary.
 
-#### Scenario: User-edited file — warn and skip
+#### Scenario: User-edited file — skip and count
 - **WHEN** the rendered output hash matches the stored cache hash but the target file content does not match the stored hash
-- **THEN** deploy logs a warning identifying the file and skips writing it; the cache entry is not updated; deploy continues to the next item
+- **THEN** deploy SHALL skip writing the file, emit a debug-level log identifying the file path, increment the user-edited counter, and continue to the next item
+
+#### Scenario: Non-TTY deploy fails on user-edited files
+- **WHEN** deploy runs in non-TTY mode (CI), one or more files were manually edited, and `--force` is not passed
+- **THEN** deploy SHALL exit with status 1 and display an error message stating the number of files that were manually edited and suggesting `--force` to override
+
+#### Scenario: Non-TTY deploy with --force succeeds despite edited files
+- **WHEN** deploy runs in non-TTY mode (CI) with `--force` and target files have been manually edited
+- **THEN** the files SHALL be overwritten with the rendered output, cache entries SHALL be updated, and deploy SHALL exit with status 0
+
+#### Scenario: TTY deploy succeeds with edited file count in summary
+- **WHEN** deploy runs in TTY mode and one or more files were manually edited without `--force`
+- **THEN** deploy SHALL exit with status 0 and the summary SHALL include the count of user-edited files
 
 #### Scenario: Force flag overrides user-edit skip
 - **WHEN** `--force` is passed and a target file has been manually edited

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -34,6 +34,7 @@ use crate::utils::path::override_workspace_dir;
 pub(crate) struct DeployStats {
     pub written: usize,
     pub skipped: usize,
+    pub user_edited: usize,
     /// Populated only during `--dry-run`; empty in normal deploys.
     pub dry_run_entries: Vec<DryRunDeployEntry>,
     /// Target paths of symlinked items (for .gitignore fence).
@@ -45,6 +46,7 @@ impl DeployStats {
     fn merge(mut self, other: Self) -> Self {
         self.written += other.written;
         self.skipped += other.skipped;
+        self.user_edited += other.user_edited;
         self.dry_run_entries.extend(other.dry_run_entries);
         self.linked_targets.extend(other.linked_targets);
         self
@@ -153,6 +155,7 @@ fn process_cache_update<T: FeatureTrait>(
         CacheUpdate::UserEditedSkipped { path } => {
             debug!("user-edited skip: path={}", path.display());
             stats.skipped += 1;
+            stats.user_edited += 1;
         }
         CacheUpdate::MergeSkipped { path, reason } => {
             debug!("merge skipped: path={}, reason={}", path.display(), reason);
@@ -485,4 +488,43 @@ pub(super) fn deploy(mut opts: DeployOptions) -> Result<()> {
         .context("unable to save cache")?;
 
     finalize_deploy(&opts, &stats, &cache)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::FeatureSettings;
+    use crate::core::features::instruction::InstructionFeature;
+    use crate::utils::dedup::DeployWorkItem;
+
+    // process_cache_update increments user_edited on UserEditedSkipped
+    #[test]
+    fn process_cache_update_user_edited_skipped() {
+        let feature = InstructionFeature::from_string("test").unwrap();
+        let settings = FeatureSettings::default();
+        let work = DeployWorkItem {
+            provider_name: "test".to_string(),
+            settings: &settings,
+            item: &feature,
+            dedup: None,
+        };
+        let cache = Arc::new(Mutex::new(CacheConfig::default()));
+        let mut stats = DeployStats::default();
+
+        process_cache_update(
+            &work,
+            "instruction",
+            "key",
+            CacheUpdate::UserEditedSkipped {
+                path: PathBuf::from("/tmp/test"),
+            },
+            &cache,
+            false,
+            &mut stats,
+        )
+        .unwrap();
+
+        assert_eq!(stats.user_edited, 1);
+        assert_eq!(stats.skipped, 1);
+    }
 }

--- a/src/cli/ui/deploy.rs
+++ b/src/cli/ui/deploy.rs
@@ -28,10 +28,24 @@ fn write_summary<W: std::io::Write>(stats: &DeployStats, writer: &mut W, tty: bo
             writeln!(writer, "Nothing deployed")
         }
     } else if tty {
+        if stats.user_edited > 0 {
+            writeln!(
+                writer,
+                "✓ {} written, {} skipped, {} edited",
+                stats.written, stats.skipped, stats.user_edited
+            )
+        } else {
+            writeln!(
+                writer,
+                "✓ {} written, {} skipped",
+                stats.written, stats.skipped
+            )
+        }
+    } else if stats.user_edited > 0 {
         writeln!(
             writer,
-            "✓ {} written, {} skipped",
-            stats.written, stats.skipped
+            "{} written, {} skipped, {} edited",
+            stats.written, stats.skipped, stats.user_edited
         )
     } else {
         writeln!(
@@ -60,6 +74,11 @@ pub(crate) fn prompt_gitignore_update(new_path_count: usize) -> bool {
 pub(crate) fn deploy_outro(stats: &DeployStats) -> String {
     if stats.written == 0 && stats.skipped == 0 {
         "Nothing deployed".to_string()
+    } else if stats.user_edited > 0 {
+        format!(
+            "{} written, {} skipped, {} edited",
+            stats.written, stats.skipped, stats.user_edited
+        )
     } else {
         format!("{} written, {} skipped", stats.written, stats.skipped)
     }
@@ -117,7 +136,7 @@ pub(crate) fn finalize_deploy(
 ) -> Result<()> {
     if opts.no_gitignore {
         print_summary(stats);
-        return Ok(());
+        return check_user_edited(stats, opts.force);
     }
 
     let workspace_root = get_workspace_dir().context("unable to get workspace directory")?;
@@ -126,7 +145,7 @@ pub(crate) fn finalize_deploy(
 
     if cache_targets.is_empty() {
         print_summary(stats);
-        return Ok(());
+        return check_user_edited(stats, opts.force);
     }
 
     let relative_paths: Vec<String> = cache_targets
@@ -148,6 +167,16 @@ pub(crate) fn finalize_deploy(
     }
 
     print_summary(stats);
+    check_user_edited(stats, opts.force)
+}
+
+fn check_user_edited(stats: &DeployStats, force: bool) -> Result<()> {
+    if stats.user_edited > 0 && !is_tui_enabled() && !force {
+        return Err(anyhow::anyhow!(
+            "{} file(s) were manually edited. Use --force to override.",
+            stats.user_edited
+        ));
+    }
     Ok(())
 }
 
@@ -161,6 +190,7 @@ mod tests {
         let stats = DeployStats {
             written: 2,
             skipped: 1,
+            user_edited: 0,
             dry_run_entries: vec![],
             linked_targets: vec![],
         };
@@ -178,6 +208,7 @@ mod tests {
         let stats = DeployStats {
             written: 0,
             skipped: 0,
+            user_edited: 0,
             dry_run_entries: vec![],
             linked_targets: vec![],
         };
@@ -186,5 +217,43 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("Nothing deployed"));
         assert!(!output.contains("✓"));
+    }
+
+    // non-TTY summary includes edited count when user_edited > 0
+    #[test]
+    fn non_tty_summary_with_user_edited() {
+        let stats = DeployStats {
+            written: 3,
+            skipped: 2,
+            user_edited: 1,
+            dry_run_entries: vec![],
+            linked_targets: vec![],
+        };
+        let mut buf = Vec::new();
+        write_summary(&stats, &mut buf, false);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("3 written"));
+        assert!(output.contains("2 skipped"));
+        assert!(output.contains("1 edited"));
+        assert!(!output.contains("✓"));
+    }
+
+    // TTY summary includes edited count when user_edited > 0
+    #[test]
+    fn tty_summary_with_user_edited() {
+        let stats = DeployStats {
+            written: 2,
+            skipped: 1,
+            user_edited: 3,
+            dry_run_entries: vec![],
+            linked_targets: vec![],
+        };
+        let mut buf = Vec::new();
+        write_summary(&stats, &mut buf, true);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("✓"));
+        assert!(output.contains("2 written"));
+        assert!(output.contains("1 skipped"));
+        assert!(output.contains("3 edited"));
     }
 }

--- a/src/templates/renderer.rs
+++ b/src/templates/renderer.rs
@@ -196,7 +196,7 @@ pub fn render_feature_with_settings<T: FeatureTrait>(
                 return Ok(CacheUpdate::Skipped);
             }
             Some(_) if !is_mergeable => {
-                warn!(
+                debug!(
                     "Target file {} was manually edited; skipping",
                     target_path.display()
                 );

--- a/tests/e2e/deploy.test.ts
+++ b/tests/e2e/deploy.test.ts
@@ -720,9 +720,14 @@ test.describe("deploy CLI – user-edit protection", () => {
 				"User edited this file.",
 			);
 
-			// Redeploy without --force — file should be preserved
-			const { exitCode } = run(["deploy", "--offline", "--no-gitignore"], d);
-			expect(exitCode).toBe(0);
+			// Redeploy without --force — file should be preserved, exit 1 in non-TTY
+			const { exitCode, stderr } = run(
+				["deploy", "--offline", "--no-gitignore"],
+				d,
+			);
+			expect(exitCode).toBe(1);
+			expect(stderr).toContain("manually edited");
+			expect(stderr).toContain("--force");
 			const afterContent = readFileSync(
 				join(d, ".mycode/instructions.md"),
 				"utf8",


### PR DESCRIPTION
## Summary
- `dotagents deploy` now fails in non-TTY/CI mode when cached target files were manually edited and `--force` is not provided.
- Deploy stats and summary output now track a separate `edited` count so CI can report a concise error without listing file paths.
- Per-file user-edit notices were downgraded from warnings to debug logs, and TTY behavior keeps succeeding with a summary that includes edited-file counts.
- Added unit and E2E coverage for the edited-file path, including the CI failure case and the `--force` override.

## Testing
- `mise check`
- `mise tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `dotagents deploy` now exits with status code 1 in CI/non-TTY environments when manually edited target files are detected, unless `--force` is used to override.
  * Consolidated error reporting displays a count of edited files rather than individual per-file warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->